### PR TITLE
Use standard ANSI types in all SDK headers

### DIFF
--- a/include/at_custom.h
+++ b/include/at_custom.h
@@ -28,7 +28,7 @@
 #include "c_types.h"
 
 #define at_port_print_irom_str(str)   do { \
-        static const uint8 irom_str[] ICACHE_RODATA_ATTR = str;  \
+        static const uint8_t irom_str[] ICACHE_RODATA_ATTR = str;  \
         at_port_print(irom_str);  \
     } while(0)
 
@@ -42,13 +42,13 @@ typedef struct
   void (*at_exeCmd)(uint8_t id);
 }at_funcationType;
 
-typedef void (*at_custom_uart_rx_intr)(uint8* data,int32 len);
+typedef void (*at_custom_uart_rx_intr)(uint8_t* data,int32_t len);
 
 typedef void (*at_custom_response_func_type)(const char *str);
 
-typedef void (*at_fake_uart_tx_func_type)(const uint8*data,uint32 length);
+typedef void (*at_fake_uart_tx_func_type)(const uint8_t*data,uint32_t length);
 
-extern uint8 at_customLinkMax;
+extern uint8_t at_customLinkMax;
 
 /**
   * @brief  Response "OK" to uart.
@@ -82,7 +82,7 @@ void at_register_response_func(at_custom_response_func_type response_func);
   *         cmd_num : the num of at cmd that custom defined
   * @retval None
   */
-void at_cmd_array_regist(at_funcationType *custom_at_cmd_array,uint32 cmd_num);
+void at_cmd_array_regist(at_funcationType *custom_at_cmd_array,uint32_t cmd_num);
 /**
   * @brief  get digit form at cmd line.the maybe alter pSrc
   * @param  p_src: at cmd line string
@@ -99,7 +99,7 @@ bool at_get_next_int_dec(char **p_src,int*result,int* err);
   *         max_len :max len of string excepted to get
   * @retval None
   */
-int32 at_data_str_copy(char *p_dest, char **p_src, int32 max_len);
+int32_t at_data_str_copy(char *p_dest, char **p_src, int32_t max_len);
 
 /**
   * @brief  initialize at module
@@ -141,7 +141,7 @@ void at_leave_special_state(void);
   *         bit15~8 : at test version
   *         bit7~0  : customized version
   */
-uint32 at_get_version(void);
+uint32_t at_get_version(void);
 
 /**
   * @brief  register custom uart rx interrupt function
@@ -157,7 +157,7 @@ void at_register_uart_rx_intr(at_custom_uart_rx_intr rx_func);
   * @param  length: data length
   * @retval data len,if ok len == length
   */
-uint32 at_fake_uart_rx(uint8* data,uint32 length);
+uint32_t at_fake_uart_rx(uint8_t* data,uint32_t length);
 
 /**
   * @brief enable fake uart,and register fake uart tx
@@ -172,7 +172,7 @@ bool at_fake_uart_enable(bool enable,at_fake_uart_tx_func_type at_fake_uart_tx_f
   * @param  ch: escape character.
   * @retval TRUE,if set ok,otherwize FALSE.
   */
-bool at_set_escape_character(uint8 ch);
+bool at_set_escape_character(uint8_t ch);
 
 /**
   * @brief Enable wpa2 enterprise command

--- a/include/c_types.h
+++ b/include/c_types.h
@@ -25,6 +25,8 @@
 #ifndef _C_TYPES_H_
 #define _C_TYPES_H_
 
+#ifdef USE_NON_STANDARD_TYPES
+
 typedef unsigned char       uint8_t;
 typedef signed char         sint8_t;
 typedef signed char         int8_t;
@@ -65,15 +67,29 @@ typedef double              real64;
 
 typedef unsigned int        size_t;
 
-#ifndef __packed
-#define __packed        __attribute__((packed))
-#endif
-
 #define LOCAL       static
 
 #ifndef NULL
 #define NULL (void *)0
-#endif /* NULL */
+#endif
+
+#ifndef __cplusplus
+typedef unsigned char   bool;
+#define BOOL            bool
+#define true            (1)
+#define false           (0)
+#define TRUE            true
+#define FALSE           false
+#endif /* !__cplusplus */
+
+#else
+#include <stdint.h>
+#include <stdbool.h>
+#endif
+
+#ifndef __packed
+#define __packed        __attribute__((packed))
+#endif
 
 /* probably should not put STATUS here */
 typedef enum {
@@ -101,16 +117,5 @@ typedef enum {
 #endif /* ICACHE_FLASH */
 
 #define STORE_ATTR __attribute__((aligned(4)))
-
-#ifndef __cplusplus
-typedef unsigned char   bool;
-#define BOOL            bool
-#define true            (1)
-#define false           (0)
-#define TRUE            true
-#define FALSE           false
-
-
-#endif /* !__cplusplus */
 
 #endif /* _C_TYPES_H_ */

--- a/include/eagle_soc.h
+++ b/include/eagle_soc.h
@@ -25,7 +25,7 @@
 #ifndef _EAGLE_SOC_H_
 #define _EAGLE_SOC_H_
 
-//Register Bits{{
+/* Register Bits */
 #define BIT31   0x80000000
 #define BIT30   0x40000000
 #define BIT29   0x20000000
@@ -58,9 +58,8 @@
 #define BIT2     0x00000004
 #define BIT1     0x00000002
 #define BIT0     0x00000001
-//}}
 
-//Registers Operation {{
+/* Registers Operation */
 #define ETS_UNCACHED_ADDR(addr) (addr)
 #define ETS_CACHED_ADDR(addr) (addr)
 
@@ -71,62 +70,62 @@
 #define SET_PERI_REG_MASK(reg, mask)   WRITE_PERI_REG((reg), (READ_PERI_REG(reg)|(mask)))
 #define GET_PERI_REG_BITS(reg, hipos,lowpos)      ((READ_PERI_REG(reg)>>(lowpos))&((1<<((hipos)-(lowpos)+1))-1))
 #define SET_PERI_REG_BITS(reg,bit_map,value,shift) (WRITE_PERI_REG((reg),(READ_PERI_REG(reg)&(~((bit_map)<<(shift))))|((value)<<(shift)) ))
-//}}
 
-//Periheral Clock {{
-#define  APB_CLK_FREQ                                80*1000000       //unit: Hz
+
+/* Peripheral Clock */
+#define  APB_CLK_FREQ                                80*1000000       /* unit: Hz */
 #define  UART_CLK_FREQ                               APB_CLK_FREQ
-#define  TIMER_CLK_FREQ                              (APB_CLK_FREQ>>8) //divided by 256
-//}}
+#define  TIMER_CLK_FREQ                              (APB_CLK_FREQ>>8) /* divided by 256*/
 
-//Peripheral device base address define{{
+
+/* Peripheral device base address define */
 #define PERIPHS_DPORT_BASEADDR              0x3ff00000
 #define PERIPHS_GPIO_BASEADDR               0x60000300
 #define PERIPHS_TIMER_BASEDDR               0x60000600
 #define PERIPHS_RTC_BASEADDR                0x60000700
 #define PERIPHS_IO_MUX						0x60000800
-//}}
 
-//Interrupt remap control registers define{{
+
+/* Interrupt remap control registers define*/
 #define EDGE_INT_ENABLE_REG                 (PERIPHS_DPORT_BASEADDR+0x04)
 #define TM1_EDGE_INT_ENABLE()             SET_PERI_REG_MASK(EDGE_INT_ENABLE_REG, BIT1)
 #define TM1_EDGE_INT_DISABLE()            CLEAR_PERI_REG_MASK(EDGE_INT_ENABLE_REG, BIT1)
-//}}
 
-//GPIO reg {{
+
+/* GPIO reg */
 #define GPIO_REG_READ(reg)                         READ_PERI_REG(PERIPHS_GPIO_BASEADDR + reg)
 #define GPIO_REG_WRITE(reg, val)                 WRITE_PERI_REG(PERIPHS_GPIO_BASEADDR + reg, val)
 #define GPIO_OUT_ADDRESS                         0x00
 #define GPIO_OUT_W1TS_ADDRESS             0x04
 #define GPIO_OUT_W1TC_ADDRESS             0x08
 
-#define GPIO_ENABLE_ADDRESS                  0x0c
+#define GPIO_ENABLE_ADDRESS           0x0c
 #define GPIO_ENABLE_W1TS_ADDRESS      0x10
 #define GPIO_ENABLE_W1TC_ADDRESS      0x14
-#define GPIO_OUT_W1TC_DATA_MASK      0x0000ffff
+#define GPIO_OUT_W1TC_DATA_MASK       0x0000ffff
 
-#define GPIO_IN_ADDRESS                            0x18
+#define GPIO_IN_ADDRESS               0x18
 
-#define GPIO_STATUS_ADDRESS                  0x1c
-#define GPIO_STATUS_W1TS_ADDRESS       0x20
+#define GPIO_STATUS_ADDRESS           0x1c
+#define GPIO_STATUS_W1TS_ADDRESS      0x20
 #define GPIO_STATUS_W1TC_ADDRESS      0x24
-#define GPIO_STATUS_INTERRUPT_MASK 0x0000ffff
+#define GPIO_STATUS_INTERRUPT_MASK    0x0000ffff
 
-#define GPIO_RTC_CALIB_SYNC                  PERIPHS_GPIO_BASEADDR+0x6c
-#define RTC_CALIB_START                           BIT31  //first write to zero, then to one to start
-#define RTC_PERIOD_NUM_MASK              0x3ff   //max 8ms
-#define GPIO_RTC_CALIB_VALUE               PERIPHS_GPIO_BASEADDR+0x70
-#define RTC_CALIB_RDY_S                           31  //after measure, flag to one, when start from zero to one, turn to zero
-#define RTC_CALIB_VALUE_MASK             0xfffff
+#define GPIO_RTC_CALIB_SYNC           PERIPHS_GPIO_BASEADDR+0x6c
+#define RTC_CALIB_START               BIT31       /* first write to zero, then to one to start */
+#define RTC_PERIOD_NUM_MASK           0x3ff       /* max 8ms */
+#define GPIO_RTC_CALIB_VALUE          PERIPHS_GPIO_BASEADDR+0x70
+#define RTC_CALIB_RDY_S               31          /* after measure, flag to one, when start from zero to one, turn to zero */
+#define RTC_CALIB_VALUE_MASK          0xfffff
 
-#define GPIO_PIN0_ADDRESS                        0x28
+#define GPIO_PIN0_ADDRESS             0x28
 
-#define GPIO_ID_PIN0                                     0
-#define GPIO_ID_PIN(n)                                   (GPIO_ID_PIN0+(n))
-#define GPIO_LAST_REGISTER_ID                GPIO_ID_PIN(15)
-#define GPIO_ID_NONE                                  0xffffffff
+#define GPIO_ID_PIN0                  0
+#define GPIO_ID_PIN(n)                (GPIO_ID_PIN0+(n))
+#define GPIO_LAST_REGISTER_ID         GPIO_ID_PIN(15)
+#define GPIO_ID_NONE                  0xffffffff
 
-#define GPIO_PIN_COUNT                              16
+#define GPIO_PIN_COUNT                16
 
 #define GPIO_PIN_CONFIG_MSB                    12
 #define GPIO_PIN_CONFIG_LSB                     11
@@ -163,32 +162,32 @@
 #define GPIO_PIN_SOURCE_MASK                  0x00000001
 #define GPIO_PIN_SOURCE_GET(x)                 (((x) & GPIO_PIN_SOURCE_MASK) >> GPIO_PIN_SOURCE_LSB)
 #define GPIO_PIN_SOURCE_SET(x)                  (((x) << GPIO_PIN_SOURCE_LSB) & GPIO_PIN_SOURCE_MASK)
-// }}
 
-// TIMER reg {{
+
+/*  TIMER reg */
 #define RTC_REG_READ(addr)                        READ_PERI_REG(PERIPHS_TIMER_BASEDDR + addr)
 #define RTC_REG_WRITE(addr, val)                WRITE_PERI_REG(PERIPHS_TIMER_BASEDDR + addr, val)
 #define RTC_CLR_REG_MASK(reg, mask)      CLEAR_PERI_REG_MASK(PERIPHS_TIMER_BASEDDR +reg, mask)
 /* Returns the current time according to the timer timer. */
 #define NOW()                                                 RTC_REG_READ(FRC2_COUNT_ADDRESS)
 
-//load initial_value to timer1
+/* load initial_value to timer1 */
 #define FRC1_LOAD_ADDRESS                    0x00
 
-//timer1's counter value(count from initial_value to 0)
+/* timer1's counter value(count from initial_value to 0) */
 #define FRC1_COUNT_ADDRESS                 0x04
 
 #define FRC1_CTRL_ADDRESS                    0x08
 
-//clear timer1's interrupt when write this address
+/* clear timer1's interrupt when write this address */
 #define FRC1_INT_ADDRESS                      0x0c
 #define FRC1_INT_CLR_MASK                   0x00000001
 
-//timer2's counter value(count from initial_value to 0)
+/* timer2's counter value(count from initial_value to 0) */
 #define FRC2_COUNT_ADDRESS                0x24
-// }}
 
-//RTC reg {{
+
+/* RTC reg */
 #define REG_RTC_BASE  PERIPHS_RTC_BASEADDR
 
 #define RTC_STORE0                              (REG_RTC_BASE + 0x030)
@@ -201,9 +200,9 @@
 #define RTC_GPIO_IN_DATA                        (REG_RTC_BASE + 0x08C)
 #define RTC_GPIO_CONF                           (REG_RTC_BASE + 0x090)
 #define PAD_XPD_DCDC_CONF                       (REG_RTC_BASE + 0x0A0)
-//}}
 
-//PIN Mux reg {{
+
+/* PIN Mux reg */
 #define PERIPHS_IO_MUX_FUNC             0x13
 #define PERIPHS_IO_MUX_FUNC_S           4
 #define PERIPHS_IO_MUX_PULLUP           BIT7
@@ -274,6 +273,6 @@
                                      |( (((FUNC&BIT2)<<2)|(FUNC&0x3))<<PERIPHS_IO_MUX_FUNC_S) );  \
     } while (0)
 
-//}}
 
-#endif //_EAGLE_SOC_H_
+
+#endif /* _EAGLE_SOC_H_ */

--- a/include/espconn.h
+++ b/include/espconn.h
@@ -24,12 +24,13 @@
 
 #ifndef __ESPCONN_H__
 #define __ESPCONN_H__
+#include "ip_addr.h"
 
-typedef sint8 err_t;
+typedef int8_t err_t;
 
 typedef void *espconn_handle;
 typedef void (* espconn_connect_callback)(void *arg);
-typedef void (* espconn_reconnect_callback)(void *arg, sint8 err);
+typedef void (* espconn_reconnect_callback)(void *arg, int8_t err);
 
 /* Definitions for error constants. */
 
@@ -75,8 +76,8 @@ enum espconn_state {
 typedef struct _esp_tcp {
     int remote_port;
     int local_port;
-    uint8 local_ip[4];
-    uint8 remote_ip[4];
+    uint8_t local_ip[4];
+    uint8_t remote_ip[4];
     espconn_connect_callback connect_callback;
     espconn_reconnect_callback reconnect_callback;
     espconn_connect_callback disconnect_callback;
@@ -86,14 +87,14 @@ typedef struct _esp_tcp {
 typedef struct _esp_udp {
     int remote_port;
     int local_port;
-    uint8 local_ip[4];
-	uint8 remote_ip[4];
+    uint8_t local_ip[4];
+	uint8_t remote_ip[4];
 } esp_udp;
 
 typedef struct _remot_info{
 	enum espconn_state state;
 	int remote_port;
-	uint8 remote_ip[4];
+	uint8_t remote_ip[4];
 }remot_info;
 
 /** A callback prototype to inform about events for a espconn */
@@ -113,7 +114,7 @@ struct espconn {
     /** A callback function that is informed about events for this espconn */
     espconn_recv_callback recv_callback;
     espconn_sent_callback sent_callback;
-    uint8 link_cnt;
+    uint8_t link_cnt;
     void *reverse;
 };
 
@@ -142,19 +143,19 @@ enum {
 };
 
 struct espconn_packet{
-	uint16 sent_length;		/* sent length successful*/
-	uint16 snd_buf_size;	/* Available buffer size for sending  */
-	uint16 snd_queuelen;	/* Available buffer space for sending */
-	uint16 total_queuelen;	/* total Available buffer space for sending */
-	uint32 packseqno;		/* seqno to be sent */
-	uint32 packseq_nxt;		/* seqno expected */
-	uint32 packnum;
+	uint16_t sent_length;		/* sent length successful*/
+	uint16_t snd_buf_size;	/* Available buffer size for sending  */
+	uint16_t snd_queuelen;	/* Available buffer space for sending */
+	uint16_t total_queuelen;	/* total Available buffer space for sending */
+	uint32_t packseqno;		/* seqno to be sent */
+	uint32_t packseq_nxt;		/* seqno expected */
+	uint32_t packnum;
 };
 
 struct mdns_info {
 	char *host_name;
 	char *server_name;
-	uint16 server_port;
+	uint16_t server_port;
 	unsigned long ipAddr;
 	char *txt_data[10];
 };
@@ -165,7 +166,7 @@ struct mdns_info {
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_connect(struct espconn *espconn);
+int8_t espconn_connect(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_disconnect
@@ -174,7 +175,7 @@ sint8 espconn_connect(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_disconnect(struct espconn *espconn);
+int8_t espconn_disconnect(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_delete
@@ -183,7 +184,7 @@ sint8 espconn_disconnect(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_delete(struct espconn *espconn);
+int8_t espconn_delete(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_accept
@@ -192,7 +193,7 @@ sint8 espconn_delete(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_accept(struct espconn *espconn);
+int8_t espconn_accept(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_create
@@ -201,7 +202,7 @@ sint8 espconn_accept(struct espconn *espconn);
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_create(struct espconn *espconn);
+int8_t espconn_create(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_tcp_get_max_con
@@ -210,7 +211,7 @@ sint8 espconn_create(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-uint8 espconn_tcp_get_max_con(void);
+uint8_t espconn_tcp_get_max_con(void);
 
 /******************************************************************************
  * FunctionName : espconn_tcp_set_max_con
@@ -219,7 +220,7 @@ uint8 espconn_tcp_get_max_con(void);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_tcp_set_max_con(uint8 num);
+int8_t espconn_tcp_set_max_con(uint8_t num);
 
 /******************************************************************************
  * FunctionName : espconn_tcp_get_max_con_allow
@@ -228,7 +229,7 @@ sint8 espconn_tcp_set_max_con(uint8 num);
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_tcp_get_max_con_allow(struct espconn *espconn);
+int8_t espconn_tcp_get_max_con_allow(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_tcp_set_max_con_allow
@@ -238,7 +239,7 @@ sint8 espconn_tcp_get_max_con_allow(struct espconn *espconn);
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_tcp_set_max_con_allow(struct espconn *espconn, uint8 num);
+int8_t espconn_tcp_set_max_con_allow(struct espconn *espconn, uint8_t num);
 
 /******************************************************************************
  * FunctionName : espconn_regist_time
@@ -248,7 +249,7 @@ sint8 espconn_tcp_set_max_con_allow(struct espconn *espconn, uint8 num);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_time(struct espconn *espconn, uint32 interval, uint8 type_flag);
+int8_t espconn_regist_time(struct espconn *espconn, uint32_t interval, uint8_t type_flag);
 
 /******************************************************************************
  * FunctionName : espconn_get_connection_info
@@ -258,7 +259,7 @@ sint8 espconn_regist_time(struct espconn *espconn, uint32 interval, uint8 type_f
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_get_connection_info(struct espconn *pespconn, remot_info **pcon_info, uint8 typeflags);
+int8_t espconn_get_connection_info(struct espconn *pespconn, remot_info **pcon_info, uint8_t typeflags);
 
 /******************************************************************************
  * FunctionName : espconn_get_packet_info
@@ -268,7 +269,7 @@ sint8 espconn_get_connection_info(struct espconn *pespconn, remot_info **pcon_in
  * Returns      : the errur code
 *******************************************************************************/
 
-sint8 espconn_get_packet_info(struct espconn *espconn, struct espconn_packet* infoarg);
+int8_t espconn_get_packet_info(struct espconn *espconn, struct espconn_packet* infoarg);
 
 /******************************************************************************
  * FunctionName : espconn_regist_sentcb
@@ -280,7 +281,7 @@ sint8 espconn_get_packet_info(struct espconn *espconn, struct espconn_packet* in
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_sentcb(struct espconn *espconn, espconn_sent_callback sent_cb);
+int8_t espconn_regist_sentcb(struct espconn *espconn, espconn_sent_callback sent_cb);
 
 /******************************************************************************
  * FunctionName : espconn_regist_sentcb
@@ -292,7 +293,7 @@ sint8 espconn_regist_sentcb(struct espconn *espconn, espconn_sent_callback sent_
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_write_finish(struct espconn *espconn, espconn_connect_callback write_finish_fn);
+int8_t espconn_regist_write_finish(struct espconn *espconn, espconn_connect_callback write_finish_fn);
 
 /******************************************************************************
  * FunctionName : espconn_send
@@ -303,7 +304,7 @@ sint8 espconn_regist_write_finish(struct espconn *espconn, espconn_connect_callb
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_send(struct espconn *espconn, uint8 *psent, uint16 length);
+int8_t espconn_send(struct espconn *espconn, uint8_t *psent, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_sent
@@ -314,7 +315,7 @@ sint8 espconn_send(struct espconn *espconn, uint8 *psent, uint16 length);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_sent(struct espconn *espconn, uint8 *psent, uint16 length);
+int8_t espconn_sent(struct espconn *espconn, uint8_t *psent, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_sendto
@@ -325,7 +326,7 @@ sint8 espconn_sent(struct espconn *espconn, uint8 *psent, uint16 length);
  * Returns      : error
 *******************************************************************************/
 
-sint16 espconn_sendto(struct espconn *espconn, uint8 *psent, uint16 length);
+int16_t espconn_sendto(struct espconn *espconn, uint8_t *psent, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_regist_connectcb
@@ -336,7 +337,7 @@ sint16 espconn_sendto(struct espconn *espconn, uint8 *psent, uint16 length);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_connectcb(struct espconn *espconn, espconn_connect_callback connect_cb);
+int8_t espconn_regist_connectcb(struct espconn *espconn, espconn_connect_callback connect_cb);
 
 /******************************************************************************
  * FunctionName : espconn_regist_recvcb
@@ -347,7 +348,7 @@ sint8 espconn_regist_connectcb(struct espconn *espconn, espconn_connect_callback
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_recvcb(struct espconn *espconn, espconn_recv_callback recv_cb);
+int8_t espconn_regist_recvcb(struct espconn *espconn, espconn_recv_callback recv_cb);
 
 /******************************************************************************
  * FunctionName : espconn_regist_reconcb
@@ -358,7 +359,7 @@ sint8 espconn_regist_recvcb(struct espconn *espconn, espconn_recv_callback recv_
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_reconcb(struct espconn *espconn, espconn_reconnect_callback recon_cb);
+int8_t espconn_regist_reconcb(struct espconn *espconn, espconn_reconnect_callback recon_cb);
 
 /******************************************************************************
  * FunctionName : espconn_regist_disconcb
@@ -368,7 +369,7 @@ sint8 espconn_regist_reconcb(struct espconn *espconn, espconn_reconnect_callback
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_regist_disconcb(struct espconn *espconn, espconn_connect_callback discon_cb);
+int8_t espconn_regist_disconcb(struct espconn *espconn, espconn_connect_callback discon_cb);
 
 /******************************************************************************
  * FunctionName : espconn_port
@@ -378,7 +379,7 @@ sint8 espconn_regist_disconcb(struct espconn *espconn, espconn_connect_callback 
  * Returns      : access port value
 *******************************************************************************/
 
-uint32 espconn_port(void);
+uint32_t espconn_port(void);
 
 /******************************************************************************
  * FunctionName : espconn_set_opt
@@ -388,7 +389,7 @@ uint32 espconn_port(void);
  * Returns      : access port value
 *******************************************************************************/
 
-sint8 espconn_set_opt(struct espconn *espconn, uint8 opt);
+int8_t espconn_set_opt(struct espconn *espconn, uint8_t opt);
 
 /******************************************************************************
  * FunctionName : espconn_clear_opt
@@ -399,7 +400,7 @@ sint8 espconn_set_opt(struct espconn *espconn, uint8 opt);
  * Returns      : the result
 *******************************************************************************/
 
-sint8 espconn_clear_opt(struct espconn *espconn, uint8 opt);
+int8_t espconn_clear_opt(struct espconn *espconn, uint8_t opt);
 
 /******************************************************************************
  * FunctionName : espconn_set_keepalive
@@ -411,7 +412,7 @@ sint8 espconn_clear_opt(struct espconn *espconn, uint8 opt);
  * Returns      : access port value
 *******************************************************************************/
 
-sint8 espconn_set_keepalive(struct espconn *espconn, uint8 level, void* optarg);
+int8_t espconn_set_keepalive(struct espconn *espconn, uint8_t level, void* optarg);
 
 /******************************************************************************
  * FunctionName : espconn_get_keepalive
@@ -422,7 +423,7 @@ sint8 espconn_set_keepalive(struct espconn *espconn, uint8 level, void* optarg);
  * Returns      : access keep alive value
 *******************************************************************************/
 
-sint8 espconn_get_keepalive(struct espconn *espconn, uint8 level, void *optarg);
+int8_t espconn_get_keepalive(struct espconn *espconn, uint8_t level, void *optarg);
 
 /******************************************************************************
  * TypedefName : dns_found_callback
@@ -464,7 +465,7 @@ err_t espconn_gethostbyname(struct espconn *pespconn, const char *hostname, ip_a
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_abort(struct espconn *espconn);
+int8_t espconn_abort(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_encry_connect
@@ -473,7 +474,7 @@ sint8 espconn_abort(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_secure_connect(struct espconn *espconn);
+int8_t espconn_secure_connect(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_encry_disconnect
@@ -482,7 +483,7 @@ sint8 espconn_secure_connect(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_secure_disconnect(struct espconn *espconn);
+int8_t espconn_secure_disconnect(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_secure_send
@@ -493,7 +494,7 @@ sint8 espconn_secure_disconnect(struct espconn *espconn);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_secure_send(struct espconn *espconn, uint8 *psent, uint16 length);
+int8_t espconn_secure_send(struct espconn *espconn, uint8_t *psent, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_encry_sent
@@ -504,7 +505,7 @@ sint8 espconn_secure_send(struct espconn *espconn, uint8 *psent, uint16 length);
  * Returns      : none
 *******************************************************************************/
 
-sint8 espconn_secure_sent(struct espconn *espconn, uint8 *psent, uint16 length);
+int8_t espconn_secure_sent(struct espconn *espconn, uint8_t *psent, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_secure_set_size
@@ -515,7 +516,7 @@ sint8 espconn_secure_sent(struct espconn *espconn, uint8 *psent, uint16 length);
  * Returns      : true or false
 *******************************************************************************/
 
-bool espconn_secure_set_size(uint8 level, uint16 size);
+bool espconn_secure_set_size(uint8_t level, uint16_t size);
 
 /******************************************************************************
  * FunctionName : espconn_secure_get_size
@@ -525,7 +526,7 @@ bool espconn_secure_set_size(uint8 level, uint16 size);
  * Returns      : buffer size for client or server
 *******************************************************************************/
 
-sint16 espconn_secure_get_size(uint8 level);
+int16_t espconn_secure_get_size(uint8_t level);
 
 /******************************************************************************
  * FunctionName : espconn_secure_ca_enable
@@ -537,7 +538,7 @@ sint16 espconn_secure_get_size(uint8 level);
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_ca_enable(uint8 level, uint32 flash_sector );
+bool espconn_secure_ca_enable(uint8_t level, uint32_t flash_sector );
 
 /******************************************************************************
  * FunctionName : espconn_secure_ca_disable
@@ -547,7 +548,7 @@ bool espconn_secure_ca_enable(uint8 level, uint32 flash_sector );
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_ca_disable(uint8 level);
+bool espconn_secure_ca_disable(uint8_t level);
 
 
 /******************************************************************************
@@ -560,7 +561,7 @@ bool espconn_secure_ca_disable(uint8 level);
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_cert_req_enable(uint8 level, uint32 flash_sector );
+bool espconn_secure_cert_req_enable(uint8_t level, uint32_t flash_sector );
 
 /******************************************************************************
  * FunctionName : espconn_secure_ca_disable
@@ -570,7 +571,7 @@ bool espconn_secure_cert_req_enable(uint8 level, uint32 flash_sector );
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_cert_req_disable(uint8 level);
+bool espconn_secure_cert_req_disable(uint8_t level);
 
 /******************************************************************************
  * FunctionName : espconn_secure_set_default_certificate
@@ -581,7 +582,7 @@ bool espconn_secure_cert_req_disable(uint8 level);
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_set_default_certificate(const uint8* certificate, uint16 length);
+bool espconn_secure_set_default_certificate(const uint8_t* certificate, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_secure_set_default_private_key
@@ -592,7 +593,7 @@ bool espconn_secure_set_default_certificate(const uint8* certificate, uint16 len
  * Returns      : result true or false
 *******************************************************************************/
 
-bool espconn_secure_set_default_private_key(const uint8* private_key, uint16 length);
+bool espconn_secure_set_default_private_key(const uint8_t* private_key, uint16_t length);
 
 /******************************************************************************
  * FunctionName : espconn_secure_accept
@@ -601,7 +602,7 @@ bool espconn_secure_set_default_private_key(const uint8* private_key, uint16 len
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_secure_accept(struct espconn *espconn);
+int8_t espconn_secure_accept(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_secure_accepts
@@ -610,7 +611,7 @@ sint8 espconn_secure_accept(struct espconn *espconn);
  * Returns      : result
 *******************************************************************************/
 
-sint8 espconn_secure_delete(struct espconn *espconn);
+int8_t espconn_secure_delete(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_igmp_join
@@ -619,7 +620,7 @@ sint8 espconn_secure_delete(struct espconn *espconn);
  * 				  multicast_ip -- multicast ip given by user
  * Returns      : none
 *******************************************************************************/
-sint8 espconn_igmp_join(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
+int8_t espconn_igmp_join(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
 
 /******************************************************************************
  * FunctionName : espconn_igmp_leave
@@ -628,7 +629,7 @@ sint8 espconn_igmp_join(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
  * 				  multicast_ip -- multicast ip given by user
  * Returns      : none
 *******************************************************************************/
-sint8 espconn_igmp_leave(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
+int8_t espconn_igmp_leave(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
 
 /******************************************************************************
  * FunctionName : espconn_recv_hold
@@ -636,7 +637,7 @@ sint8 espconn_igmp_leave(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
  * Parameters   : espconn -- espconn to hold
  * Returns      : none
 *******************************************************************************/
-sint8 espconn_recv_hold(struct espconn *pespconn);
+int8_t espconn_recv_hold(struct espconn *pespconn);
 
 /******************************************************************************
  * FunctionName : espconn_recv_unhold
@@ -644,7 +645,7 @@ sint8 espconn_recv_hold(struct espconn *pespconn);
  * Parameters   : espconn -- espconn to unhold
  * Returns      : none
 *******************************************************************************/
-sint8 espconn_recv_unhold(struct espconn *pespconn);
+int8_t espconn_recv_unhold(struct espconn *pespconn);
 
 /******************************************************************************
  * FunctionName : espconn_recved_len
@@ -652,7 +653,7 @@ sint8 espconn_recv_unhold(struct espconn *pespconn);
  * Parameters   : espconn -- espconn to unhold
  * Returns      : result
 *******************************************************************************/
-sint16 espconn_recved_len(struct espconn *espconn);
+int16_t espconn_recved_len(struct espconn *espconn);
 
 /******************************************************************************
  * FunctionName : espconn_mdns_init
@@ -742,7 +743,7 @@ void espconn_mdns_enable(void);
  * 			      dnsserver -- IP address of the DNS server to set
  *  Returns     : none
 *******************************************************************************/
-void espconn_dns_setserver(uint8 numdns, ip_addr_t *dnsserver);
+void espconn_dns_setserver(uint8_t numdns, ip_addr_t *dnsserver);
 /******************************************************************************
  * FunctionName : espconn_dns_getserver
  * Description  : get dns server.
@@ -750,6 +751,6 @@ void espconn_dns_setserver(uint8 numdns, ip_addr_t *dnsserver);
  *                be < DNS_MAX_SERVERS = 2
  *  Returns     : dnsserver -- IP address of the DNS server to set
 *******************************************************************************/
-ip_addr_t espconn_dns_getserver(uint8 numdns);
+ip_addr_t espconn_dns_getserver(uint8_t numdns);
 #endif
 

--- a/include/espnow.h
+++ b/include/espnow.h
@@ -33,8 +33,8 @@ enum esp_now_role {
 	ESP_NOW_ROLE_MAX,
 };
 
-typedef void (*esp_now_recv_cb_t)(u8 *mac_addr, u8 *data, u8 len);
-typedef void (*esp_now_send_cb_t)(u8 *mac_addr, u8 status);
+typedef void (*esp_now_recv_cb_t)(uint8_t *mac_addr, uint8_t *data, uint8_t len);
+typedef void (*esp_now_send_cb_t)(uint8_t *mac_addr, uint8_t status);
 
 int esp_now_init(void);
 int esp_now_deinit(void);
@@ -45,29 +45,29 @@ int esp_now_unregister_send_cb(void);
 int esp_now_register_recv_cb(esp_now_recv_cb_t cb);
 int esp_now_unregister_recv_cb(void);
 
-int esp_now_send(u8 *da, u8 *data, int len);
+int esp_now_send(uint8_t *da, uint8_t *data, int len);
 
-int esp_now_add_peer(u8 *mac_addr, u8 role, u8 channel, u8 *key, u8 key_len);
-int esp_now_del_peer(u8 *mac_addr);
+int esp_now_add_peer(uint8_t *mac_addr, uint8_t role, uint8_t channel, uint8_t *key, uint8_t key_len);
+int esp_now_del_peer(uint8_t *mac_addr);
 
-int esp_now_set_self_role(u8 role);
+int esp_now_set_self_role(uint8_t role);
 int esp_now_get_self_role(void);
 
-int esp_now_set_peer_role(u8 *mac_addr, u8 role);
-int esp_now_get_peer_role(u8 *mac_addr);
+int esp_now_set_peer_role(uint8_t *mac_addr, uint8_t role);
+int esp_now_get_peer_role(uint8_t *mac_addr);
 
-int esp_now_set_peer_channel(u8 *mac_addr, u8 channel);
-int esp_now_get_peer_channel(u8 *mac_addr);
+int esp_now_set_peer_channel(uint8_t *mac_addr, uint8_t channel);
+int esp_now_get_peer_channel(uint8_t *mac_addr);
 
-int esp_now_set_peer_key(u8 *mac_addr, u8 *key, u8 key_len);
-int esp_now_get_peer_key(u8 *mac_addr, u8 *key, u8 *key_len);
+int esp_now_set_peer_key(uint8_t *mac_addr, uint8_t *key, uint8_t key_len);
+int esp_now_get_peer_key(uint8_t *mac_addr, uint8_t *key, uint8_t *key_len);
 
-u8 *esp_now_fetch_peer(bool restart);
+uint8_t *esp_now_fetch_peer(bool restart);
 
-int esp_now_is_peer_exist(u8 *mac_addr);
+int esp_now_is_peer_exist(uint8_t *mac_addr);
 
-int esp_now_get_cnt_info(u8 *all_cnt, u8 *encrypt_cnt);
+int esp_now_get_cnt_info(uint8_t *all_cnt, uint8_t *encrypt_cnt);
 
-int esp_now_set_kok(u8 *key, u8 len);
+int esp_now_set_kok(uint8_t *key, uint8_t len);
 
 #endif

--- a/include/ets_sys.h
+++ b/include/ets_sys.h
@@ -65,8 +65,8 @@ typedef void (* ets_isr_t)(void *);
 void ets_intr_lock(void);
 void ets_intr_unlock(void);
 void ets_isr_attach(int i, ets_isr_t func, void *arg);
-void ets_isr_mask(uint32 mask);
-void ets_isr_unmask(uint32 unmask);
+void ets_isr_mask(uint32_t mask);
+void ets_isr_unmask(uint32_t unmask);
 
 void NmiTimSetFunc(void (*func)(void));
 

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -47,7 +47,7 @@ typedef enum {
 #define GPIO_INPUT_GET(gpio_no)     ((gpio_input_get()>>gpio_no)&BIT0)
 
 /* GPIO interrupt handler, registered through gpio_intr_handler_register */
-typedef void (* gpio_intr_handler_fn_t)(uint32 intr_mask, void *arg);
+typedef void (* gpio_intr_handler_fn_t)(uint32_t intr_mask, void *arg);
 
 
 /*
@@ -67,15 +67,15 @@ void gpio_init(void);
  * writes is significant, calling code should divide a single call
  * into multiple calls.
  */
-void gpio_output_set(uint32 set_mask,
-                     uint32 clear_mask,
-                     uint32 enable_mask,
-                     uint32 disable_mask);
+void gpio_output_set(uint32_t set_mask,
+                     uint32_t clear_mask,
+                     uint32_t enable_mask,
+                     uint32_t disable_mask);
 
 /*
  * Sample the value of GPIO input pins and returns a bitmask.
  */
-uint32 gpio_input_get(void);
+uint32_t gpio_input_get(void);
 
 /*
  * Set the specified GPIO register to the specified value.
@@ -83,10 +83,10 @@ uint32 gpio_input_get(void);
  * expected to be used during normal operation.  It is intended
  * mainly for debug, or for unusual requirements.
  */
-void gpio_register_set(uint32 reg_id, uint32 value);
+void gpio_register_set(uint32_t reg_id, uint32_t value);
 
 /* Get the current value of the specified GPIO register. */
-uint32 gpio_register_get(uint32 reg_id);
+uint32_t gpio_register_get(uint32_t reg_id);
 
 /*
  * Register an application-specific interrupt handler for GPIO pin
@@ -102,18 +102,18 @@ uint32 gpio_register_get(uint32 reg_id);
 void gpio_intr_handler_register(gpio_intr_handler_fn_t fn, void *arg);
 
 /* Determine which GPIO interrupts are pending. */
-uint32 gpio_intr_pending(void);
+uint32_t gpio_intr_pending(void);
 
 /*
  * Acknowledge GPIO interrupts.
  * Intended to be called from the gpio_intr_handler_fn.
  */
-void gpio_intr_ack(uint32 ack_mask);
+void gpio_intr_ack(uint32_t ack_mask);
 
-void gpio_pin_wakeup_enable(uint32 i, GPIO_INT_TYPE intr_state);
+void gpio_pin_wakeup_enable(uint32_t i, GPIO_INT_TYPE intr_state);
 
-void gpio_pin_wakeup_disable();
+void gpio_pin_wakeup_disable(void);
 
-void gpio_pin_intr_state_set(uint32 i, GPIO_INT_TYPE intr_state);
+void gpio_pin_intr_state_set(uint32_t i, GPIO_INT_TYPE intr_state);
 
-#endif // _GPIO_H_
+#endif /* _GPIO_H_ */

--- a/include/ip_addr.h
+++ b/include/ip_addr.h
@@ -28,7 +28,7 @@
 #include "c_types.h"
 
 struct ip_addr {
-    uint32 addr;
+    uint32_t addr;
 };
 
 typedef struct ip_addr ip_addr_t;
@@ -55,27 +55,27 @@ struct ip_info {
 /** Set an IP address given by the four byte-parts.
     Little-endian version that prevents the use of htonl. */
 #define IP4_ADDR(ipaddr, a,b,c,d) \
-        (ipaddr)->addr = ((uint32)((d) & 0xff) << 24) | \
-                         ((uint32)((c) & 0xff) << 16) | \
-                         ((uint32)((b) & 0xff) << 8)  | \
-                          (uint32)((a) & 0xff)
+        (ipaddr)->addr = ((uint32_t)((d) & 0xff) << 24) | \
+                         ((uint32_t)((c) & 0xff) << 16) | \
+                         ((uint32_t)((b) & 0xff) << 8)  | \
+                          (uint32_t)((a) & 0xff)
 
-#define ip4_addr1(ipaddr) (((uint8*)(ipaddr))[0])
-#define ip4_addr2(ipaddr) (((uint8*)(ipaddr))[1])
-#define ip4_addr3(ipaddr) (((uint8*)(ipaddr))[2])
-#define ip4_addr4(ipaddr) (((uint8*)(ipaddr))[3])
+#define ip4_addr1(ipaddr) (((uint8_t*)(ipaddr))[0])
+#define ip4_addr2(ipaddr) (((uint8_t*)(ipaddr))[1])
+#define ip4_addr3(ipaddr) (((uint8_t*)(ipaddr))[2])
+#define ip4_addr4(ipaddr) (((uint8_t*)(ipaddr))[3])
 
-#define ip4_addr1_16(ipaddr) ((uint16)ip4_addr1(ipaddr))
-#define ip4_addr2_16(ipaddr) ((uint16)ip4_addr2(ipaddr))
-#define ip4_addr3_16(ipaddr) ((uint16)ip4_addr3(ipaddr))
-#define ip4_addr4_16(ipaddr) ((uint16)ip4_addr4(ipaddr))
+#define ip4_addr1_16(ipaddr) ((uint16_t)ip4_addr1(ipaddr))
+#define ip4_addr2_16(ipaddr) ((uint16_t)ip4_addr2(ipaddr))
+#define ip4_addr3_16(ipaddr) ((uint16_t)ip4_addr3(ipaddr))
+#define ip4_addr4_16(ipaddr) ((uint16_t)ip4_addr4(ipaddr))
 
 
 /** 255.255.255.255 */
-#define IPADDR_NONE         ((uint32)0xffffffffUL)
+#define IPADDR_NONE         ((uint32_t)0xffffffffUL)
 /** 0.0.0.0 */
-#define IPADDR_ANY          ((uint32)0x00000000UL)
-uint32 ipaddr_addr(const char *cp);
+#define IPADDR_ANY          ((uint32_t)0x00000000UL)
+uint32_t ipaddr_addr(const char *cp);
 
 #define IP2STR(ipaddr) ip4_addr1_16(ipaddr), \
     ip4_addr2_16(ipaddr), \

--- a/include/json/jsontree.h
+++ b/include/json/jsontree.h
@@ -132,7 +132,7 @@ const char *jsontree_path_name(const struct jsontree_context *js_ctx,
                                int depth);
 
 void jsontree_write_int(const struct jsontree_context *js_ctx, int value);
-void jsontree_write_int_array(const struct jsontree_context *js_ctx, const int *text, uint32 length);
+void jsontree_write_int_array(const struct jsontree_context *js_ctx, const int *text, uint32_t length);
 
 void jsontree_write_atom(const struct jsontree_context *js_ctx,
                          const char *text);

--- a/include/osapi.h
+++ b/include/osapi.h
@@ -26,6 +26,7 @@
 #define _OSAPI_H_
 
 #include <string.h>
+#include <stdarg.h>
 #include "os_type.h"
 #include "user_config.h"
 
@@ -76,6 +77,7 @@ void ets_timer_setfn(os_timer_t *ptimer, os_timer_func_t *pfunction, void *parg)
 int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 int ets_snprintf(char *str, unsigned int size, const char *format, ...)  __attribute__ ((format (printf, 3, 4)));
+int ets_vsnprintf(char *str, unsigned int size,  const char *format, va_list argptr);
 
 #define os_sprintf_plus  ets_sprintf
 #define os_sprintf(buf, fmt, ...) os_sprintf_plus(buf, fmt, ##__VA_ARGS__)

--- a/include/ping.h
+++ b/include/ping.h
@@ -25,28 +25,27 @@
 #ifndef __PING_H__
 #define __PING_H__
 
-
 typedef void (* ping_recv_function)(void* arg, void *pdata);
 typedef void (* ping_sent_function)(void* arg, void *pdata);
 
 struct ping_option{
-	uint32 count;
-	uint32 ip;
-	uint32 coarse_time;
+	uint32_t count;
+	uint32_t ip;
+	uint32_t coarse_time;
 	ping_recv_function recv_function;
 	ping_sent_function sent_function;
 	void* reverse;
 };
 
 struct ping_resp{
-	uint32 total_count;
-	uint32 resp_time;
-	uint32 seqno;
-	uint32 timeout_count;
-	uint32 bytes;
-	uint32 total_bytes;
-	uint32 total_time;
-	sint8  ping_err;
+	uint32_t total_count;
+	uint32_t resp_time;
+	uint32_t seqno;
+	uint32_t timeout_count;
+	uint32_t bytes;
+	uint32_t total_bytes;
+	uint32_t total_time;
+	int8_t  ping_err;
 };
 
 bool ping_start(struct ping_option *ping_opt);

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -36,23 +36,23 @@
 #define PWM_CHANNEL_NUM_MAX 8 
 
 struct pwm_param {
-    uint32 period;
-    uint32 freq;
-    uint32  duty[PWM_CHANNEL_NUM_MAX];  //PWM_CHANNEL<=8
+    uint32_t period;
+    uint32_t freq;
+    uint32_t  duty[PWM_CHANNEL_NUM_MAX];  /* PWM_CHANNEL<=8 */
 };
 
 
 /* pwm_init should be called only once, for now  */
-void pwm_init(uint32 period, uint32 *duty,uint32 pwm_channel_num,uint32 (*pin_info_list)[3]);
+void pwm_init(uint32_t period, uint32_t *duty,uint32_t pwm_channel_num,uint32_t (*pin_info_list)[3]);
 void pwm_start(void);
 
-void pwm_set_duty(uint32 duty, uint8 channel);
-uint32 pwm_get_duty(uint8 channel);
-void pwm_set_period(uint32 period);
-uint32 pwm_get_period(void);
+void pwm_set_duty(uint32_t duty, uint8_t channel);
+uint32_t pwm_get_duty(uint8_t channel);
+void pwm_set_period(uint32_t period);
+uint32_t pwm_get_period(void);
 
-uint32 get_pwm_version(void);
-void set_pwm_debug_en(uint8 print_en);
+uint32_t get_pwm_version(void);
+void set_pwm_debug_en(uint8_t print_en);
 
 #endif
 

--- a/include/simple_pair.h
+++ b/include/simple_pair.h
@@ -34,14 +34,14 @@ typedef enum {
 	SP_ST_WAIT_TIMEOUT,
 	SP_ST_SEND_ERROR,
 	SP_ST_KEY_INSTALL_ERR,
-	SP_ST_KEY_OVERLAP_ERR,  //means the same macaddr has two different keys 
+	SP_ST_KEY_OVERLAP_ERR,  /* means the same macaddr has two different keys */
 	SP_ST_OP_ERROR,
 	SP_ST_UNKNOWN_ERROR,
 	SP_ST_MAX,
 } SP_ST_t;
 
 
-typedef void (*simple_pair_status_cb_t)(u8 *sa, u8 status);
+typedef void (*simple_pair_status_cb_t)(uint8_t *sa, uint8_t status);
 
 int register_simple_pair_status_cb(simple_pair_status_cb_t cb);
 void unregister_simple_pair_status_cb(void);
@@ -57,8 +57,8 @@ int simple_pair_sta_start_negotiate(void);
 int simple_pair_ap_start_negotiate(void);
 int simple_pair_ap_refuse_negotiate(void);
 
-int simple_pair_set_peer_ref(u8 *peer_mac, u8 *tmp_key, u8 *ex_key);
-int simple_pair_get_peer_ref(u8 *peer_mac, u8 *tmp_key, u8 *ex_key);
+int simple_pair_set_peer_ref(uint8_t *peer_mac, uint8_t *tmp_key, uint8_t *ex_key);
+int simple_pair_get_peer_ref(uint8_t *peer_mac, uint8_t *tmp_key, uint8_t *ex_key);
 
 
 #endif /* __SIMPLE_PAIR_H__ */

--- a/include/smartconfig.h
+++ b/include/smartconfig.h
@@ -44,7 +44,7 @@ typedef void (*sc_callback_t)(sc_status status, void *pdata);
 const char *smartconfig_get_version(void);
 bool smartconfig_start(sc_callback_t cb, ...);
 bool smartconfig_stop(void);
-bool esptouch_set_timeout(uint8 time_s); //15s~255s, offset:45s
+bool esptouch_set_timeout(uint8_t time_s); /* 15s~255s, offset:45s */
 bool smartconfig_set_type(sc_type type);
 
 #endif

--- a/include/sntp.h
+++ b/include/sntp.h
@@ -10,19 +10,19 @@
 /**
  * get the seconds since Jan 01, 1970, 00:00 (GMT + 8)
  */
-uint32 sntp_get_current_timestamp();
+uint32_t sntp_get_current_timestamp(void);
 /**
  * get real time (GTM + 8 time zone)
  */
-char* sntp_get_real_time(long t);
+char* sntp_get_real_time(uint32_t t);
 /**
  * SNTP get time_zone default GMT + 8
  */
-sint8 sntp_get_timezone(void);
+int8_t sntp_get_timezone(void);
 /**
  * SNTP set time_zone (default GMT + 8)
  */
-bool sntp_set_timezone(sint8 timezone);
+bool sntp_set_timezone(int8_t timezone);
 /**
  * Initialize this module.
  * Send out request instantly or after SNTP_STARTUP_DELAY(_FUNC).
@@ -38,7 +38,7 @@ void sntp_stop(void);
  * @param numdns the index of the NTP server to set must be < SNTP_MAX_SERVERS
  * @param dnsserver IP address of the NTP server to set
  */
-void sntp_setserver(unsigned char idx, ip_addr_t *addr);
+void sntp_setserver(uint8_t idx, ip_addr_t *addr);
 /**
  * Obtain one of the currently configured by IP address (or DHCP) NTP servers
  *
@@ -46,14 +46,14 @@ void sntp_setserver(unsigned char idx, ip_addr_t *addr);
  * @return IP address of the indexed NTP server or "ip_addr_any" if the NTP
  *         server has not been configured by address (or at all).
  */
-ip_addr_t sntp_getserver(unsigned char idx);
+ip_addr_t sntp_getserver(uint8_t idx);
 /**
  * Initialize one of the NTP servers by name
  *
  * @param numdns the index of the NTP server to set must be < SNTP_MAX_SERVERS,now sdk support SNTP_MAX_SERVERS = 3
  * @param dnsserver DNS name of the NTP server to set, to be resolved at contact time
  */
-void sntp_setservername(unsigned char idx, char *server);
+void sntp_setservername(uint8_t idx, char *server);
 /**
  * Obtain one of the currently configured by name NTP servers.
  *
@@ -61,7 +61,7 @@ void sntp_setservername(unsigned char idx, char *server);
  * @return IP address of the indexed NTP server or NULL if the NTP
  *         server has not been configured by name (or at all)
  */
-char *sntp_getservername(unsigned char idx);
+char *sntp_getservername(uint8_t idx);
 
 #define sntp_servermode_dhcp(x)
 

--- a/include/spi_flash.h
+++ b/include/spi_flash.h
@@ -24,6 +24,7 @@
 
 #ifndef SPI_FLASH_H
 #define SPI_FLASH_H
+#include <c_types.h>
 
 typedef enum {
     SPI_FLASH_RESULT_OK,
@@ -32,26 +33,26 @@ typedef enum {
 } SpiFlashOpResult;
 
 typedef struct{
-	uint32	deviceId;
-	uint32	chip_size;    // chip size in byte
-	uint32	block_size;
-	uint32  sector_size;
-	uint32  page_size;
-	uint32  status_mask;
+	uint32_t	deviceId;
+	uint32_t	chip_size;    /* chip size in byte */
+	uint32_t	block_size;
+	uint32_t  sector_size;
+	uint32_t  page_size;
+	uint32_t  status_mask;
 } SpiFlashChip;
 
 #define SPI_FLASH_SEC_SIZE      4096
 
-uint32 spi_flash_get_id(void);
-SpiFlashOpResult spi_flash_erase_sector(uint16 sec);
-SpiFlashOpResult spi_flash_write(uint32 des_addr, uint32 *src_addr, uint32 size);
-SpiFlashOpResult spi_flash_read(uint32 src_addr, uint32 *des_addr, uint32 size);
+uint32_t spi_flash_get_id(void);
+SpiFlashOpResult spi_flash_erase_sector(uint16_t sec);
+SpiFlashOpResult spi_flash_write(uint32_t des_addr, uint32_t *src_addr, uint32_t size);
+SpiFlashOpResult spi_flash_read(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
 
 typedef SpiFlashOpResult (* user_spi_flash_read)(
 		SpiFlashChip *spi,
-		uint32 src_addr,
-		uint32 *des_addr,
-        uint32 size);
+		uint32_t src_addr,
+		uint32_t *des_addr,
+        uint32_t size);
 
 void spi_flash_set_read_func(user_spi_flash_read read);
 

--- a/include/upgrade.h
+++ b/include/upgrade.h
@@ -40,19 +40,19 @@
 
 typedef void (*upgrade_states_check_callback)(void * arg);
 
-//#define UPGRADE_SSL_ENABLE
+/* #define UPGRADE_SSL_ENABLE */
 
 struct upgrade_server_info {
-    uint8 ip[4];
-    uint16 port;
+    uint8_t  ip[4];
+    uint16_t port;
 
-    uint8 upgrade_flag;
+    uint8_t upgrade_flag;
 
-    uint8 pre_version[16];
-    uint8 upgrade_version[16];
+    uint8_t pre_version[16];
+    uint8_t upgrade_version[16];
 
-    uint32 check_times;
-    uint8 *url;
+    uint32_t check_times;
+    uint8_t *url;
 
     upgrade_states_check_callback check_cb;
     struct espconn *pespconn;
@@ -62,12 +62,12 @@ struct upgrade_server_info {
 #define UPGRADE_FLAG_START      0x01
 #define UPGRADE_FLAG_FINISH     0x02
 
-void system_upgrade_init();
-void system_upgrade_deinit();
-bool system_upgrade(uint8 *data, uint16 len);
+void system_upgrade_init(void);
+void system_upgrade_deinit(void);
+bool system_upgrade(uint8_t *data, uint16_t len);
 
 #ifdef UPGRADE_SSL_ENABLE
-bool system_upgrade_start_ssl(struct upgrade_server_info *server);	// not supported now
+bool system_upgrade_start_ssl(struct upgrade_server_info *server);	/* not supported now */
 #else
 bool system_upgrade_start(struct upgrade_server_info *server);
 #endif

--- a/include/user_interface.h
+++ b/include/user_interface.h
@@ -53,13 +53,13 @@ enum rst_reason {
 };
 
 struct rst_info{
-    uint32 reason;
-    uint32 exccause;
-    uint32 epc1;
-    uint32 epc2;
-    uint32 epc3;
-    uint32 excvaddr;
-    uint32 depc;
+	uint32_t reason;
+	uint32_t exccause;
+	uint32_t epc1;
+	uint32_t epc2;
+	uint32_t epc3;
+	uint32_t excvaddr;
+	uint32_t depc;
 };
 
 struct rst_info* system_get_rst_info(void);
@@ -70,17 +70,17 @@ struct rst_info* system_get_rst_info(void);
 void system_restore(void);
 void system_restart(void);
 
-bool system_deep_sleep_set_option(uint8 option);
-bool system_deep_sleep(uint64 time_in_us);
-bool system_deep_sleep_instant(uint64 time_in_us);
+bool system_deep_sleep_set_option(uint8_t option);
+bool system_deep_sleep(uint64_t time_in_us);
+bool system_deep_sleep_instant(uint64_t time_in_us);
 
-uint8 system_upgrade_userbin_check(void);
+uint8_t system_upgrade_userbin_check(void);
 void system_upgrade_reboot(void);
-uint8 system_upgrade_flag_check();
-void system_upgrade_flag_set(uint8 flag);
+uint8_t system_upgrade_flag_check(void);
+void system_upgrade_flag_set(uint8_t flag);
 
 void system_timer_reinit(void);
-uint32 system_get_time(void);
+uint32_t system_get_time(void);
 
 /* user task's prio must be 0/1/2 !!!*/
 enum {
@@ -90,35 +90,35 @@ enum {
     USER_TASK_PRIO_MAX
 };
 
-bool system_os_task(os_task_t task, uint8 prio, os_event_t *queue, uint8 qlen);
-bool system_os_post(uint8 prio, os_signal_t sig, os_param_t par);
+bool system_os_task(os_task_t task, uint8_t prio, os_event_t *queue, uint8_t qlen);
+bool system_os_post(uint8_t prio, os_signal_t sig, os_param_t par);
 
 void system_print_meminfo(void);
-uint32 system_get_free_heap_size(void);
+uint32_t system_get_free_heap_size(void);
 
-void system_set_os_print(uint8 onoff);
-uint8 system_get_os_print();
+void system_set_os_print(uint8_t onoff);
+uint8_t system_get_os_print(void);
 
-uint64 system_mktime(uint32 year, uint32 mon, uint32 day, uint32 hour, uint32 min, uint32 sec);
+uint64_t system_mktime(uint32_t year, uint32_t mon, uint32_t day, uint32_t hour, uint32_t min, uint32_t sec);
 
-uint32 system_get_chip_id(void);
+uint32_t system_get_chip_id(void);
 
 typedef void (* init_done_cb_t)(void);
 
 void system_init_done_cb(init_done_cb_t cb);
 
-uint32 system_rtc_clock_cali_proc(void);
-uint32 system_get_rtc_time(void);
+uint32_t system_rtc_clock_cali_proc(void);
+uint32_t system_get_rtc_time(void);
 
-bool system_rtc_mem_read(uint8 src_addr, void *des_addr, uint16 load_size);
-bool system_rtc_mem_write(uint8 des_addr, const void *src_addr, uint16 save_size);
+bool system_rtc_mem_read(uint8_t src_addr, void *des_addr, uint16_t load_size);
+bool system_rtc_mem_write(uint8_t des_addr, const void *src_addr, uint16_t save_size);
 
 void system_uart_swap(void);
 void system_uart_de_swap(void);
 
-uint16 system_adc_read(void);
-void system_adc_read_fast(uint16 *adc_addr, uint16 adc_num, uint8 adc_clk_div);
-uint16 system_get_vdd33(void);
+uint16_t system_adc_read(void);
+void system_adc_read_fast(uint16_t *adc_addr, uint16_t adc_num, uint8_t adc_clk_div);
+uint16_t system_get_vdd33(void);
 
 const char *system_get_sdk_version(void);
 
@@ -128,16 +128,16 @@ const char *system_get_sdk_version(void);
 #define SYS_BOOT_NORMAL_BIN        0
 #define SYS_BOOT_TEST_BIN        1
 
-uint8 system_get_boot_version(void);
-uint32 system_get_userbin_addr(void);
-uint8 system_get_boot_mode(void);
-bool system_restart_enhance(uint8 bin_type, uint32 bin_addr);
+uint8_t system_get_boot_version(void);
+uint32_t system_get_userbin_addr(void);
+uint8_t system_get_boot_mode(void);
+bool system_restart_enhance(uint8_t bin_type, uint32_t bin_addr);
 
 #define SYS_CPU_80MHZ    80
 #define SYS_CPU_160MHZ    160
 
-bool system_update_cpu_freq(uint8 freq);
-uint8 system_get_cpu_freq(void);
+bool system_update_cpu_freq(uint8_t freq);
+uint8_t system_get_cpu_freq(void);
 
 enum flash_size_map {
     FLASH_SIZE_4M_MAP_256_256 = 0,  /**<  Flash size : 4Mbits. Map : 256KBytes + 256KBytes */
@@ -155,13 +155,14 @@ enum flash_size_map {
 
 enum flash_size_map system_get_flash_size_map(void);
 
-void system_phy_set_max_tpw(uint8 max_tpw);
-void system_phy_set_tpw_via_vdd33(uint16 vdd33);
-void system_phy_set_rfoption(uint8 option);
-void system_phy_set_powerup_option(uint8 option);
+void system_phy_set_max_tpw(uint8_t max_tpw);
+void system_phy_set_tpw_via_vdd33(uint16_t vdd33);
+void system_phy_set_rfoption(uint8_t option);
+void system_phy_set_powerup_option(uint8_t option);
+void system_phy_freq_trace_enable(bool enable);
 
-bool system_param_save_with_protect(uint16 start_sec, void *param, uint16 len);
-bool system_param_load(uint16 start_sec, uint16 offset, void *param, uint16 len);
+bool system_param_save_with_protect(uint16_t start_sec, void *param, uint16_t len);
+bool system_param_load(uint16_t start_sec, uint16_t offset, void *param, uint16_t len);
 
 void system_soft_wdt_stop(void);
 void system_soft_wdt_restart(void);
@@ -193,27 +194,27 @@ typedef enum _cipher_type {
     CIPHER_UNKNOWN,
 } CIPHER_TYPE;
 
-uint8 wifi_get_opmode(void);
-uint8 wifi_get_opmode_default(void);
-bool wifi_set_opmode(uint8 opmode);
-bool wifi_set_opmode_current(uint8 opmode);
-uint8 wifi_get_broadcast_if(void);
-bool wifi_set_broadcast_if(uint8 interface);
+uint8_t wifi_get_opmode(void);
+uint8_t wifi_get_opmode_default(void);
+bool wifi_set_opmode(uint8_t opmode);
+bool wifi_set_opmode_current(uint8_t opmode);
+uint8_t wifi_get_broadcast_if(void);
+bool wifi_set_broadcast_if(uint8_t interface);
 
 struct bss_info {
     STAILQ_ENTRY(bss_info)     next;
 
-    uint8 bssid[6];
-    uint8 ssid[32];
-    uint8 ssid_len;
-    uint8 channel;
-    sint8 rssi;
+    uint8_t bssid[6];
+    uint8_t ssid[32];
+    uint8_t ssid_len;
+    uint8_t channel;
+    int8_t rssi;
     AUTH_MODE authmode;
-    uint8 is_hidden;
-    sint16 freq_offset;
-    sint16 freqcal_val;
-    uint8 *esp_mesh_ie;
-    uint8 simple_pair;
+    uint8_t is_hidden;
+    int16_t freq_offset;
+    int16_t freqcal_val;
+    uint8_t *esp_mesh_ie;
+    uint8_t simple_pair;
     CIPHER_TYPE pairwise_cipher;
     CIPHER_TYPE group_cipher;
     uint32_t phy_11b:1;
@@ -226,25 +227,25 @@ struct bss_info {
 typedef struct _scaninfo {
     STAILQ_HEAD(, bss_info) *pbss;
     struct espconn *pespconn;
-    uint8 totalpage;
-    uint8 pagenum;
-    uint8 page_sn;
-    uint8 data_cnt;
+    uint8_t totalpage;
+    uint8_t pagenum;
+    uint8_t page_sn;
+    uint8_t data_cnt;
 } scaninfo;
 
 typedef void (* scan_done_cb_t)(void *arg, STATUS status);
 
 typedef struct {
-    int8  rssi;
+    int8_t  rssi;
     AUTH_MODE  authmode;
 } wifi_fast_scan_threshold_t;
 
 struct station_config {
-    uint8 ssid[32];
-    uint8 password[64];
-    uint8 bssid_set;    // Note: If bssid_set is 1, station will just connect to the router
+    uint8_t ssid[32];
+    uint8_t password[64];
+    uint8_t bssid_set;    // Note: If bssid_set is 1, station will just connect to the router
                         // with both ssid[] and bssid[] matched. Please check about this.
-    uint8 bssid[6];
+    uint8_t bssid[6];
     wifi_fast_scan_threshold_t threshold;
     bool open_and_wep_mode_disable; // Can connect to open/wep router by default.
 };
@@ -260,7 +261,7 @@ bool wifi_station_disconnect(void);
 void wifi_enable_signaling_measurement(void);
 void wifi_disable_signaling_measurement(void);
 
-sint8 wifi_station_get_rssi(void);
+int8_t wifi_station_get_rssi(void);
 
 typedef enum {
     WIFI_SCAN_TYPE_ACTIVE = 0,  /**< active scan */
@@ -282,18 +283,18 @@ typedef union {
 } wifi_scan_time_t;
 
 struct scan_config {
-    uint8 *ssid;    // Note: ssid == NULL, don't filter ssid.
-    uint8 *bssid;    // Note: bssid == NULL, don't filter bssid.
-    uint8 channel;    // Note: channel == 0, scan all channels, otherwise scan set channel.
-    uint8 show_hidden;    // Note: show_hidden == 1, can get hidden ssid routers' info.
+    uint8_t *ssid;    // Note: ssid == NULL, don't filter ssid.
+    uint8_t *bssid;    // Note: bssid == NULL, don't filter bssid.
+    uint8_t channel;    // Note: channel == 0, scan all channels, otherwise scan set channel.
+    uint8_t show_hidden;    // Note: show_hidden == 1, can get hidden ssid routers' info.
     wifi_scan_type_t scan_type; // scan type, active or passive
     wifi_scan_time_t scan_time; // scan time per channel
 };
 
 bool wifi_station_scan(struct scan_config *config, scan_done_cb_t cb);
 
-uint8 wifi_station_get_auto_connect(void);
-bool wifi_station_set_auto_connect(uint8 set);
+uint8_t wifi_station_get_auto_connect(void);
+bool wifi_station_set_auto_connect(uint8_t set);
 
 bool wifi_station_set_reconnect_policy(bool set);
 
@@ -311,37 +312,37 @@ enum dhcp_status {
     DHCP_STARTED
 };
 
-uint8 wifi_station_get_connect_status(void);
+uint8_t wifi_station_get_connect_status(void);
 
-uint8 wifi_station_get_current_ap_id(void);
-bool wifi_station_ap_change(uint8 current_ap_id);
-bool wifi_station_ap_number_set(uint8 ap_number);
-uint8 wifi_station_get_ap_info(struct station_config config[]);
+uint8_t wifi_station_get_current_ap_id(void);
+bool wifi_station_ap_change(uint8_t current_ap_id);
+bool wifi_station_ap_number_set(uint8_t ap_number);
+uint8_t wifi_station_get_ap_info(struct station_config config[]);
 
 bool wifi_station_dhcpc_start(void);
 bool wifi_station_dhcpc_stop(void);
 enum dhcp_status wifi_station_dhcpc_status(void);
-bool wifi_station_dhcpc_set_maxtry(uint8 num);
+bool wifi_station_dhcpc_set_maxtry(uint8_t num);
 
 char* wifi_station_get_hostname(void);
 bool wifi_station_set_hostname(char *name);
 
-int wifi_station_set_cert_key(uint8 *client_cert, int client_cert_len,
-    uint8 *private_key, int private_key_len,
-    uint8 *private_key_passwd, int private_key_passwd_len);
+int wifi_station_set_cert_key(uint8_t *client_cert, int client_cert_len,
+    uint8_t *private_key, int private_key_len,
+    uint8_t *private_key_passwd, int private_key_passwd_len);
 void wifi_station_clear_cert_key(void);
-int wifi_station_set_username(uint8 *username, int len);
+int wifi_station_set_username(uint8_t *username, int len);
 void wifi_station_clear_username(void);
 
 struct softap_config {
-    uint8 ssid[32];
-    uint8 password[64];
-    uint8 ssid_len;    // Note: Recommend to set it according to your ssid
-    uint8 channel;    // Note: support 1 ~ 13
+    uint8_t ssid[32];
+    uint8_t password[64];
+    uint8_t ssid_len;    // Note: Recommend to set it according to your ssid
+    uint8_t channel;    // Note: support 1 ~ 13
     AUTH_MODE authmode;    // Note: Don't support AUTH_WEP in softAP mode.
-    uint8 ssid_hidden;    // Note: default 0
-    uint8 max_connection;    // Note: default 4, max 4
-    uint16 beacon_interval;    // Note: support 100 ~ 60000 ms, default 100
+    uint8_t ssid_hidden;    // Note: default 0
+    uint8_t max_connection;    // Note: default 4, max 4
+    uint16_t beacon_interval;    // Note: support 100 ~ 60000 ms, default 100
 };
 
 bool wifi_softap_get_config(struct softap_config *config);
@@ -352,7 +353,7 @@ bool wifi_softap_set_config_current(struct softap_config *config);
 struct station_info {
     STAILQ_ENTRY(station_info)    next;
 
-    uint8 bssid[6];
+    uint8_t bssid[6];
     struct ip_addr ip;
 };
 
@@ -368,7 +369,7 @@ enum dhcps_offer_option{
     OFFER_END
 };
 
-uint8 wifi_softap_get_station_num(void);
+uint8_t wifi_softap_get_station_num(void);
 struct station_info * wifi_softap_get_station_info(void);
 void wifi_softap_free_station_info(void);
 
@@ -377,34 +378,34 @@ bool wifi_softap_dhcps_stop(void);
 
 bool wifi_softap_set_dhcps_lease(struct dhcps_lease *please);
 bool wifi_softap_get_dhcps_lease(struct dhcps_lease *please);
-uint32 wifi_softap_get_dhcps_lease_time(void);
-bool wifi_softap_set_dhcps_lease_time(uint32 minute);
+uint32_t wifi_softap_get_dhcps_lease_time(void);
+bool wifi_softap_set_dhcps_lease_time(uint32_t minute);
 bool wifi_softap_reset_dhcps_lease_time(void);
 
 enum dhcp_status wifi_softap_dhcps_status(void);
-bool wifi_softap_set_dhcps_offer_option(uint8 level, void* optarg);
+bool wifi_softap_set_dhcps_offer_option(uint8_t level, void* optarg);
 
 #define STATION_IF      0x00
 #define SOFTAP_IF       0x01
 
-bool wifi_get_ip_info(uint8 if_index, struct ip_info *info);
-bool wifi_set_ip_info(uint8 if_index, struct ip_info *info);
-bool wifi_get_macaddr(uint8 if_index, uint8 *macaddr);
-bool wifi_set_macaddr(uint8 if_index, uint8 *macaddr);
+bool wifi_get_ip_info(uint8_t if_index, struct ip_info *info);
+bool wifi_set_ip_info(uint8_t if_index, struct ip_info *info);
+bool wifi_get_macaddr(uint8_t if_index, uint8_t *macaddr);
+bool wifi_set_macaddr(uint8_t if_index, uint8_t *macaddr);
 
-uint8 wifi_get_channel(void);
-bool wifi_set_channel(uint8 channel);
+uint8_t wifi_get_channel(void);
+bool wifi_set_channel(uint8_t channel);
 
-void wifi_status_led_install(uint8 gpio_id, uint32 gpio_name, uint8 gpio_func);
-void wifi_status_led_uninstall();
+void wifi_status_led_install(uint8_t gpio_id, uint32_t gpio_name, uint8_t gpio_func);
+void wifi_status_led_uninstall(void);
 
 /** Get the absolute difference between 2 u32_t values (correcting overflows)
  * 'a' is expected to be 'higher' (without overflow) than 'b'. */
 #define ESP_U32_DIFF(a, b) (((a) >= (b)) ? ((a) - (b)) : (((a) + ((b) ^ 0xFFFFFFFF) + 1)))
 
-void wifi_promiscuous_enable(uint8 promiscuous);
+void wifi_promiscuous_enable(uint8_t promiscuous);
 
-typedef void (* wifi_promiscuous_cb_t)(uint8 *buf, uint16 len);
+typedef void (* wifi_promiscuous_cb_t)(uint8_t *buf, uint16_t len);
 
 void wifi_set_promiscuous_rx_cb(wifi_promiscuous_cb_t cb);
 
@@ -434,20 +435,20 @@ bool wifi_set_sleep_type(enum sleep_type type);
 enum sleep_type wifi_get_sleep_type(void);
 bool wifi_set_sleep_level(enum sleep_level level);
 enum sleep_level wifi_get_sleep_level(void);
-bool wifi_set_listen_interval(uint8 interval);
-uint8 wifi_get_listen_interval(void);
+bool wifi_set_listen_interval(uint8_t interval);
+uint8_t wifi_get_listen_interval(void);
 
 void wifi_fpm_open(void);
 void wifi_fpm_close(void);
 void wifi_fpm_do_wakeup(void);
-sint8 wifi_fpm_do_sleep(uint32 sleep_time_in_us);
+int8_t wifi_fpm_do_sleep(uint32_t sleep_time_in_us);
 void wifi_fpm_set_sleep_type(enum sleep_type type);
 enum sleep_type wifi_fpm_get_sleep_type(void);
 
 typedef void (*fpm_wakeup_cb)(void);
 void wifi_fpm_set_wakeup_cb(fpm_wakeup_cb cb);
 
-void wifi_fpm_auto_sleep_set_in_null_mode(uint8 req);
+void wifi_fpm_auto_sleep_set_in_null_mode(uint8_t req);
 
 enum {
     EVENT_STAMODE_CONNECTED = 0,
@@ -496,22 +497,22 @@ enum {
 };
 
 typedef struct {
-    uint8 ssid[32];
-    uint8 ssid_len;
-    uint8 bssid[6];
-    uint8 channel;
+    uint8_t ssid[32];
+    uint8_t ssid_len;
+    uint8_t bssid[6];
+    uint8_t channel;
 } Event_StaMode_Connected_t;
 
 typedef struct {
-    uint8 ssid[32];
-    uint8 ssid_len;
-    uint8 bssid[6];
-    uint8 reason;
+    uint8_t ssid[32];
+    uint8_t ssid_len;
+    uint8_t bssid[6];
+    uint8_t reason;
 } Event_StaMode_Disconnected_t;
 
 typedef struct {
-    uint8 old_mode;
-    uint8 new_mode;
+    uint8_t old_mode;
+    uint8_t new_mode;
 } Event_StaMode_AuthMode_Change_t;
 
 typedef struct {
@@ -521,29 +522,29 @@ typedef struct {
 } Event_StaMode_Got_IP_t;
 
 typedef struct {
-    uint8 mac[6];
-    uint8 aid;
+    uint8_t mac[6];
+    uint8_t aid;
 } Event_SoftAPMode_StaConnected_t;
 
 typedef struct {
-    uint8 mac[6];
+    uint8_t mac[6];
     struct ip_addr ip;
-    uint8 aid;
+    uint8_t aid;
 } Event_SoftAPMode_Distribute_Sta_IP_t;
 
 typedef struct {
-    uint8 mac[6];
-    uint8 aid;
+    uint8_t mac[6];
+    uint8_t aid;
 } Event_SoftAPMode_StaDisconnected_t;
 
 typedef struct {
     int rssi;
-    uint8 mac[6];
+    uint8_t mac[6];
 } Event_SoftAPMode_ProbeReqRecved_t;
 
 typedef struct {
-    uint8 old_opmode;
-    uint8 new_opmode;
+    uint8_t old_opmode;
+    uint8_t new_opmode;
 } Event_OpMode_Change_t;
 
 typedef union {
@@ -559,7 +560,7 @@ typedef union {
 } Event_Info_u;
 
 typedef struct _esp_event {
-    uint32 event;
+    uint32_t event;
     Event_Info_u event_info;
 } System_Event_t;
 
@@ -589,15 +590,15 @@ bool wifi_wps_start(void);
 typedef void (*wps_st_cb_t)(int status);
 bool wifi_set_wps_cb(wps_st_cb_t cb);
 
-typedef void (*freedom_outside_cb_t)(uint8 status);
+typedef void (*freedom_outside_cb_t)(uint8_t status);
 int wifi_register_send_pkt_freedom_cb(freedom_outside_cb_t cb);
 void wifi_unregister_send_pkt_freedom_cb(void);
-int wifi_send_pkt_freedom(uint8 *buf, int len, bool sys_seq);
+int wifi_send_pkt_freedom(uint8_t *buf, int len, bool sys_seq);
 
 int wifi_rfid_locp_recv_open(void);
 void wifi_rfid_locp_recv_close(void);
 
-typedef void (*rfid_locp_cb_t)(uint8 *frm, int len, int rssi);
+typedef void (*rfid_locp_cb_t)(uint8_t *frm, int len, int rssi);
 int wifi_register_rfid_locp_recv_cb(rfid_locp_cb_t cb);
 void wifi_unregister_rfid_locp_recv_cb(void);
 
@@ -617,8 +618,8 @@ enum FIXED_RATE {
 #define FIXED_RATE_MASK_AP        0x02
 #define FIXED_RATE_MASK_ALL        0x03
 
-int wifi_set_user_fixed_rate(uint8 enable_mask, uint8 rate);
-int wifi_get_user_fixed_rate(uint8 *enable_mask, uint8 *rate);
+int wifi_set_user_fixed_rate(uint8_t enable_mask, uint8_t rate);
+int wifi_get_user_fixed_rate(uint8_t *enable_mask, uint8_t *rate);
 
 enum support_rate {
     RATE_11B5M    = 0,
@@ -635,7 +636,7 @@ enum support_rate {
     RATE_11G36M    = 11,
 };
 
-int wifi_set_user_sup_rate(uint8 min, uint8 max);
+int wifi_set_user_sup_rate(uint8_t min, uint8_t max);
 
 enum RATE_11B_ID {
     RATE_11B_B11M    = 0,
@@ -685,9 +686,9 @@ enum RATE_11N_ID {
 #define LIMIT_RATE_MASK_AP        0x02
 #define LIMIT_RATE_MASK_ALL        0x03
 
-bool wifi_set_user_rate_limit(uint8 mode, uint8 ifidx, uint8 max, uint8 min);
-uint8 wifi_get_user_limit_rate_mask(void);
-bool wifi_set_user_limit_rate_mask(uint8 enable_mask);
+bool wifi_set_user_rate_limit(uint8_t mode, uint8_t ifidx, uint8_t max, uint8_t min);
+uint8_t wifi_get_user_limit_rate_mask(void);
+bool wifi_set_user_limit_rate_mask(uint8_t enable_mask);
 
 enum {
     USER_IE_BEACON = 0,
@@ -698,16 +699,16 @@ enum {
     USER_IE_MAX
 };
 
-typedef void (*user_ie_manufacturer_recv_cb_t)(uint8 type, const uint8 sa[6], const uint8 m_oui[3], uint8 *ie, uint8 ie_len, int rssi);
+typedef void (*user_ie_manufacturer_recv_cb_t)(uint8_t type, const uint8_t sa[6], const uint8_t m_oui[3], uint8_t *ie, uint8_t ie_len, int rssi);
 
-bool wifi_set_user_ie(bool enable, uint8 *m_oui, uint8 type, uint8 *user_ie, uint8 len);
+bool wifi_set_user_ie(bool enable, uint8_t *m_oui, uint8_t type, uint8_t *user_ie, uint8_t len);
 int wifi_register_user_ie_manufacturer_recv_cb(user_ie_manufacturer_recv_cb_t cb);
 void wifi_unregister_user_ie_manufacturer_recv_cb(void);
 
-void wifi_enable_gpio_wakeup(uint32 i, GPIO_INT_TYPE intr_status);
+void wifi_enable_gpio_wakeup(uint32_t i, GPIO_INT_TYPE intr_status);
 void wifi_disable_gpio_wakeup(void);
 
-void uart_div_modify(uint8 uart_no, uint32 DivLatchValue);
+void uart_div_modify(uint8_t uart_no, uint32_t DivLatchValue);
 
 typedef enum {
     WIFI_COUNTRY_POLICY_AUTO,   /**< Country policy is auto, use the country info of AP to which the station is connected */

--- a/include/wpa2_enterprise.h
+++ b/include/wpa2_enterprise.h
@@ -36,24 +36,24 @@ typedef int (* get_time_func_t)(struct os_time *t);
 
 int  wifi_station_set_wpa2_enterprise_auth(int enable);
 
-int  wifi_station_set_enterprise_cert_key(u8 *client_cert, int client_cert_len,
-			u8 *private_key, int private_key_len,
-			u8 *private_key_passwd, int private_key_passwd_len);
+int  wifi_station_set_enterprise_cert_key(uint8_t *client_cert, int client_cert_len,
+			uint8_t *private_key, int private_key_len,
+			uint8_t *private_key_passwd, int private_key_passwd_len);
 void  wifi_station_clear_enterprise_cert_key(void);
 
-int  wifi_station_set_enterprise_ca_cert(u8 *ca_cert, int ca_cert_len);
+int  wifi_station_set_enterprise_ca_cert(uint8_t *ca_cert, int ca_cert_len);
 void  wifi_station_clear_enterprise_ca_cert(void);
 
-int wifi_station_set_enterprise_identity(u8 *identity, int len);
+int wifi_station_set_enterprise_identity(uint8_t *identity, int len);
 void wifi_station_clear_enterprise_identity(void);
 
-int  wifi_station_set_enterprise_username(u8 *username, int len);
+int  wifi_station_set_enterprise_username(uint8_t *username, int len);
 void  wifi_station_clear_enterprise_username(void);
 
-int  wifi_station_set_enterprise_password(u8 *password, int len);
+int  wifi_station_set_enterprise_password(uint8_t *password, int len);
 void  wifi_station_clear_enterprise_password(void);
 
-int  wifi_station_set_enterprise_new_password(u8 *new_password, int len);
+int  wifi_station_set_enterprise_new_password(uint8_t *new_password, int len);
 void  wifi_station_clear_enterprise_new_password(void);
 
 void  wifi_station_set_enterprise_disable_time_check(bool disable);


### PR DESCRIPTION
Change all types in the SDK headers to be standard ANSI types, and make this the default in c_types.h by use of the define USE_NON_STANDARD_TYPES

In addition, make sure all function definitions are full prototypes, and add one or two remaining undeclared internal functions (eg. vsnprintf() )