### PR TITLE
Changed Makefile settings to compile under more platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ APP?=0
 SPI_SPEED?=40
 SPI_MODE?=QIO
 SPI_SIZE_MAP?=0
+PYTHON?=python
 
 ifeq ($(BOOT), new)
     boot = new
@@ -279,7 +280,7 @@ endif
 	@echo "!!!"
 	
 ifeq ($(app), 0)
-	@python ../tools/gen_appbin.py $< 0 $(mode) $(freqdiv) $(size_map) $(app)
+	@$(PYTHON) ../tools/gen_appbin.py $< 0 $(mode) $(freqdiv) $(size_map) $(app)
 	@mv eagle.app.flash.bin ../bin/eagle.flash.bin
 	@mv eagle.app.v6.irom0text.bin ../bin/eagle.irom0text.bin
 	@rm eagle.app.v6.*
@@ -289,10 +290,10 @@ ifeq ($(app), 0)
 	@echo "eagle.irom0text.bin---->0x10000"
 else
     ifneq ($(boot), new)
-		@python ../tools/gen_appbin.py $< 1 $(mode) $(freqdiv) $(size_map) $(app)
+		@$(PYTHON) ../tools/gen_appbin.py $< 1 $(mode) $(freqdiv) $(size_map) $(app)
 		@echo "Support boot_v1.1 and +"
     else
-		@python ../tools/gen_appbin.py $< 2 $(mode) $(freqdiv) $(size_map) $(app)
+		@$(PYTHON) ../tools/gen_appbin.py $< 2 $(mode) $(freqdiv) $(size_map) $(app)
 
     	ifeq ($(size_map), 6)
 		@echo "Support boot_v1.4 and +"


### PR DESCRIPTION
Hello,
some sdk dependecies, such as python ver 2.7 have platform depedent naming because of their deprecation etc. For example python 2.7 in Arch linux based distributions is called python2 (not python).
I changed Makefile so that not debian users could build their code for esp8266 platform without Makefile modifications. They now can use PYTHON= option, for ex. `make COMPILE=gcc BOOT=new APP=1 SPI_SPEED=40 SPI_MODE=QIO SPI_SIZE_MAP=5 PYTHON=python2`.
