### PR TITLE
fix mqtt example compile warnings

### DIFF
--- a/examples/esp_mqtt_proj/include/mqtt_config.h
+++ b/examples/esp_mqtt_proj/include/mqtt_config.h
@@ -23,7 +23,7 @@ typedef enum{
 #define STA_SSID "AP_SSID"    // your AP/router SSID to config your device networking
 #define STA_PASS "AP_Passwd" // your AP/router password
 
-#define DEFAULT_SECURITY    NO_TLS      // very important: you must config DEFAULT_SECURITY for SSL/TLS
+#define MQTT_SECURITY NO_TLS  // very important: you must config MQTT_SECURITY for SSL/TLS
 
 #define CA_CERT_FLASH_ADDRESS 0x77              // CA certificate address in flash to read, 0x77 means address 0x77000
 #define CLIENT_CERT_FLASH_ADDRESS 0x78          // client certificate and private key address in flash to read, 0x78 means address 0x78000

--- a/examples/esp_mqtt_proj/modules/config.c
+++ b/examples/esp_mqtt_proj/modules/config.c
@@ -98,7 +98,7 @@ CFG_Load()
 		os_strncpy(sysCfg.mqtt_user, MQTT_USER, sizeof(sysCfg.mqtt_user) - 1);
 		os_strncpy(sysCfg.mqtt_pass, MQTT_PASS, sizeof(sysCfg.mqtt_pass) - 1);
 
-		sysCfg.security = DEFAULT_SECURITY;	/* default non ssl */
+		sysCfg.security = MQTT_SECURITY;	/* default non ssl */
 
 		sysCfg.mqtt_keepalive = MQTT_KEEPALIVE;
 

--- a/examples/esp_mqtt_proj/mqtt/include/debug.h
+++ b/examples/esp_mqtt_proj/mqtt/include/debug.h
@@ -11,13 +11,17 @@
 #if defined(GLOBAL_DEBUG_ON)
 #define MQTT_DEBUG_ON
 #endif
+
+#ifndef INFO
 #if defined(MQTT_DEBUG_ON)
 #define INFO( format, ... ) os_printf( format, ## __VA_ARGS__ )
 #else
 #define INFO( format, ... )
 #endif
-// #ifndef INFO
-// #define INFO os_printf
-// #endif
-
+#endif
+/*
+#ifndef INFO
+#define INFO os_printf
+#endif
+*/
 #endif /* USER_DEBUG_H_ */

--- a/examples/esp_mqtt_proj/mqtt/include/mqtt.h
+++ b/examples/esp_mqtt_proj/mqtt/include/mqtt.h
@@ -94,7 +94,7 @@ typedef void (*MqttDataCallback)(uint32_t *args, const char* topic, uint32_t top
 typedef struct  {
 	struct espconn *pCon;
 	uint8_t security;
-	uint8_t* host;
+	char* host;
 	uint32_t port;
 	ip_addr_t ip;
 	mqtt_state_t  mqtt_state;
@@ -130,17 +130,18 @@ typedef struct  {
 #define MQTT_EVENT_TYPE_EXITED 			7
 #define MQTT_EVENT_TYPE_PUBLISH_CONTINUATION 8
 
-void ICACHE_FLASH_ATTR MQTT_InitConnection(MQTT_Client *mqttClient, uint8_t* host, uint32_t port, uint8_t security);
-void ICACHE_FLASH_ATTR MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_user, uint8_t* client_pass, uint32_t keepAliveTime, uint8_t cleanSession);
+void ICACHE_FLASH_ATTR MQTT_InitConnection(MQTT_Client *mqttClient, const char* host, uint32_t port, uint8_t security);
+void ICACHE_FLASH_ATTR MQTT_InitClient(MQTT_Client *mqttClient, const char* client_id, const char* client_user, const char* client_pass, uint32_t keepAliveTime, uint8_t cleanSession);
 void ICACHE_FLASH_ATTR MQTT_DeleteClient(MQTT_Client *mqttClient);
-void ICACHE_FLASH_ATTR MQTT_InitLWT(MQTT_Client *mqttClient, uint8_t* will_topic, uint8_t* will_msg, uint8_t will_qos, uint8_t will_retain);
+void ICACHE_FLASH_ATTR MQTT_InitLWT(MQTT_Client *mqttClient, const char* will_topic, const char* will_msg, uint8_t will_qos, uint8_t will_retain);
 void ICACHE_FLASH_ATTR MQTT_OnConnected(MQTT_Client *mqttClient, MqttCallback connectedCb);
 void ICACHE_FLASH_ATTR MQTT_OnDisconnected(MQTT_Client *mqttClient, MqttCallback disconnectedCb);
 void ICACHE_FLASH_ATTR MQTT_OnPublished(MQTT_Client *mqttClient, MqttCallback publishedCb);
 void ICACHE_FLASH_ATTR MQTT_OnTimeout(MQTT_Client *mqttClient, MqttCallback timeoutCb);
 void ICACHE_FLASH_ATTR MQTT_OnData(MQTT_Client *mqttClient, MqttDataCallback dataCb);
-BOOL ICACHE_FLASH_ATTR MQTT_Subscribe(MQTT_Client *client, char* topic, uint8_t qos);
-BOOL ICACHE_FLASH_ATTR MQTT_UnSubscribe(MQTT_Client *client, char* topic);
+BOOL ICACHE_FLASH_ATTR MQTT_Subscribe(MQTT_Client *client, const char* topic, uint8_t qos);
+BOOL ICACHE_FLASH_ATTR MQTT_UnSubscribe(MQTT_Client *client, const char* topic);
+BOOL ICACHE_FLASH_ATTR MQTT_Ping(MQTT_Client *client);
 void ICACHE_FLASH_ATTR MQTT_Connect(MQTT_Client *mqttClient);
 void ICACHE_FLASH_ATTR MQTT_Disconnect(MQTT_Client *mqttClient);
 BOOL ICACHE_FLASH_ATTR MQTT_Publish(MQTT_Client *client, const char* topic, const char* data, int data_length, int qos, int retain);

--- a/examples/esp_mqtt_proj/mqtt/include/utils.h
+++ b/examples/esp_mqtt_proj/mqtt/include/utils.h
@@ -3,7 +3,7 @@
 
 #include "c_types.h"
 
-uint32_t ICACHE_FLASH_ATTR UTILS_Atoh(const int8_t *s);
-uint8_t ICACHE_FLASH_ATTR UTILS_StrToIP(const int8_t* str, void *ip);
-uint8_t ICACHE_FLASH_ATTR UTILS_IsIPV4 (int8_t *str);
+uint32_t ICACHE_FLASH_ATTR UTILS_Atoh(const char *s);
+uint8_t ICACHE_FLASH_ATTR UTILS_StrToIP(const char *str, void *ip);
+uint8_t ICACHE_FLASH_ATTR UTILS_IsIPV4 (const char *str);
 #endif

--- a/examples/esp_mqtt_proj/mqtt/mqtt.c
+++ b/examples/esp_mqtt_proj/mqtt/mqtt.c
@@ -41,12 +41,12 @@
 #include "queue.h"
 #include "include/utils.h"
 
-#define MQTT_TASK_PRIO                2
+#define MQTT_TASK_PRIO              2
 #define MQTT_TASK_QUEUE_SIZE        1
 #define MQTT_SEND_TIMOUT            5
 
 #ifndef QUEUE_BUFFER_SIZE
-#define QUEUE_BUFFER_SIZE             2048
+#define QUEUE_BUFFER_SIZE           2048
 #endif
 
 unsigned char *default_certificate;
@@ -81,10 +81,10 @@ mqtt_dns_found(const char *name, ip_addr_t *ipaddr, void *arg)
         os_memcpy(client->pCon->proto.tcp->remote_ip, &ipaddr->addr, 4);
         if (client->security) {
 #ifdef MQTT_SSL_ENABLE
-            if(DEFAULT_SECURITY >= ONE_WAY_ANTHENTICATION ) {
+            if(MQTT_SECURITY >= ONE_WAY_ANTHENTICATION ) {
                 espconn_secure_ca_enable(ESPCONN_CLIENT,CA_CERT_FLASH_ADDRESS);
             }
-            if(DEFAULT_SECURITY >= TWO_WAY_ANTHENTICATION) {
+            if(MQTT_SECURITY >= TWO_WAY_ANTHENTICATION) {
                 espconn_secure_cert_req_enable(ESPCONN_CLIENT,CLIENT_CERT_FLASH_ADDRESS);
             }
 
@@ -121,7 +121,7 @@ deliver_publish(MQTT_Client* client, uint8_t* message, int length)
 
 }
 
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_send_keepalive(MQTT_Client *client)
 {
     INFO("\r\nMQTT: Send keepalive packet to %s:%d!\r\n", client->host, client->port);
@@ -162,7 +162,7 @@ mqtt_send_keepalive(MQTT_Client *client)
   * @param  mqttClient: The mqtt client which contain TCP client
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_delete(MQTT_Client *mqttClient)
 {
     if (mqttClient->pCon != NULL) {
@@ -180,7 +180,7 @@ mqtt_tcpclient_delete(MQTT_Client *mqttClient)
   * @param  mqttClient: The mqtt client
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_client_delete(MQTT_Client *mqttClient)
 {
     mqtt_tcpclient_delete(mqttClient);
@@ -230,7 +230,6 @@ mqtt_client_delete(MQTT_Client *mqttClient)
     }
 }
 
-
 /**
   * @brief  Client received callback function.
   * @param  arg: contain the ip link information
@@ -238,7 +237,7 @@ mqtt_client_delete(MQTT_Client *mqttClient)
   * @param  len: the lenght of received data
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_recv(void *arg, char *pdata, unsigned short len)
 {
     uint8_t msg_type;
@@ -377,7 +376,7 @@ READPACKET:
   * @param  arg: contain the ip link information
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_sent_cb(void *arg)
 {
     struct espconn *pCon = (struct espconn *)arg;
@@ -394,7 +393,8 @@ mqtt_tcpclient_sent_cb(void *arg)
     system_os_post(MQTT_TASK_PRIO, 0, (os_param_t)client);
 }
 
-void ICACHE_FLASH_ATTR mqtt_timer(void *arg)
+LOCAL void ICACHE_FLASH_ATTR
+mqtt_timer(void *arg)
 {
     MQTT_Client* client = (MQTT_Client*)arg;
 
@@ -419,7 +419,7 @@ void ICACHE_FLASH_ATTR mqtt_timer(void *arg)
         client->sendTimeout --;
 }
 
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_discon_cb(void *arg)
 {
 
@@ -448,7 +448,7 @@ mqtt_tcpclient_discon_cb(void *arg)
   * @param  arg: contain the ip link information
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_connect_cb(void *arg)
 {
     struct espconn *pCon = (struct espconn *)arg;
@@ -488,7 +488,7 @@ mqtt_tcpclient_connect_cb(void *arg)
   * @param  arg: contain the ip link information
   * @retval None
   */
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 mqtt_tcpclient_recon_cb(void *arg, sint8 errType)
 {
     struct espconn *pCon = (struct espconn *)arg;
@@ -545,7 +545,7 @@ MQTT_Publish(MQTT_Client *client, const char* topic, const char* data, int data_
   * @retval TRUE if success queue
   */
 BOOL ICACHE_FLASH_ATTR
-MQTT_Subscribe(MQTT_Client *client, char* topic, uint8_t qos)
+MQTT_Subscribe(MQTT_Client *client, const char* topic, uint8_t qos)
 {
     uint8_t dataBuffer[MQTT_BUF_SIZE];
     uint16_t dataLen;
@@ -572,7 +572,7 @@ MQTT_Subscribe(MQTT_Client *client, char* topic, uint8_t qos)
   * @retval TRUE if success queue
   */
 BOOL ICACHE_FLASH_ATTR
-MQTT_UnSubscribe(MQTT_Client *client, char* topic)
+MQTT_UnSubscribe(MQTT_Client *client, const char* topic)
 {
     uint8_t dataBuffer[MQTT_BUF_SIZE];
     uint16_t dataLen;
@@ -618,7 +618,7 @@ MQTT_Ping(MQTT_Client *client)
     return TRUE;
 }
 
-void ICACHE_FLASH_ATTR
+LOCAL void ICACHE_FLASH_ATTR
 MQTT_Task(os_event_t *e)
 {
     MQTT_Client* client = (MQTT_Client*)e->par;
@@ -699,13 +699,13 @@ MQTT_Task(os_event_t *e)
   * @retval None
   */
 void ICACHE_FLASH_ATTR
-MQTT_InitConnection(MQTT_Client *mqttClient, uint8_t* host, uint32_t port, uint8_t security)
+MQTT_InitConnection(MQTT_Client *mqttClient, const char* host, uint32_t port, uint8_t security)
 {
     uint32_t temp;
     INFO("MQTT_InitConnection\r\n");
     os_memset(mqttClient, 0, sizeof(MQTT_Client));
     temp = os_strlen(host);
-    mqttClient->host = (uint8_t*)os_zalloc(temp + 1);
+    mqttClient->host = (char*)os_zalloc(temp + 1);
     os_strcpy(mqttClient->host, host);
     mqttClient->host[temp] = 0;
     mqttClient->port = port;
@@ -723,7 +723,7 @@ MQTT_InitConnection(MQTT_Client *mqttClient, uint8_t* host, uint32_t port, uint8
   * @retval None
   */
 void ICACHE_FLASH_ATTR
-MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_user, uint8_t* client_pass, uint32_t keepAliveTime, uint8_t cleanSession)
+MQTT_InitClient(MQTT_Client *mqttClient, const char* client_id, const char* client_user, const char* client_pass, uint32_t keepAliveTime, uint8_t cleanSession)
 {
     uint32_t temp;
     INFO("MQTT_InitClient\r\n");
@@ -731,14 +731,14 @@ MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_use
     os_memset(&mqttClient->connect_info, 0, sizeof(mqtt_connect_info_t));
 
     temp = os_strlen(client_id);
-    mqttClient->connect_info.client_id = (uint8_t*)os_zalloc(temp + 1);
+    mqttClient->connect_info.client_id = (char*)os_zalloc(temp + 1);
     os_strcpy(mqttClient->connect_info.client_id, client_id);
     mqttClient->connect_info.client_id[temp] = 0;
 
     if (client_user)
     {
         temp = os_strlen(client_user);
-        mqttClient->connect_info.username = (uint8_t*)os_zalloc(temp + 1);
+        mqttClient->connect_info.username = (char*)os_zalloc(temp + 1);
         os_strcpy(mqttClient->connect_info.username, client_user);
         mqttClient->connect_info.username[temp] = 0;
     }
@@ -746,7 +746,7 @@ MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_use
     if (client_pass)
     {
         temp = os_strlen(client_pass);
-        mqttClient->connect_info.password = (uint8_t*)os_zalloc(temp + 1);
+        mqttClient->connect_info.password = (char*)os_zalloc(temp + 1);
         os_strcpy(mqttClient->connect_info.password, client_pass);
         mqttClient->connect_info.password[temp] = 0;
     }
@@ -768,17 +768,18 @@ MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_use
     system_os_task(MQTT_Task, MQTT_TASK_PRIO, mqtt_procTaskQueue, MQTT_TASK_QUEUE_SIZE);
     system_os_post(MQTT_TASK_PRIO, 0, (os_param_t)mqttClient);
 }
+
 void ICACHE_FLASH_ATTR
-MQTT_InitLWT(MQTT_Client *mqttClient, uint8_t* will_topic, uint8_t* will_msg, uint8_t will_qos, uint8_t will_retain)
+MQTT_InitLWT(MQTT_Client *mqttClient, const char* will_topic, const char* will_msg, uint8_t will_qos, uint8_t will_retain)
 {
     uint32_t temp;
     temp = os_strlen(will_topic);
-    mqttClient->connect_info.will_topic = (uint8_t*)os_zalloc(temp + 1);
+    mqttClient->connect_info.will_topic = (char*)os_zalloc(temp + 1);
     os_strcpy(mqttClient->connect_info.will_topic, will_topic);
     mqttClient->connect_info.will_topic[temp] = 0;
 
     temp = os_strlen(will_msg);
-    mqttClient->connect_info.will_message = (uint8_t*)os_zalloc(temp + 1);
+    mqttClient->connect_info.will_message = (char*)os_zalloc(temp + 1);
     os_strcpy(mqttClient->connect_info.will_message, will_msg);
     mqttClient->connect_info.will_message[temp] = 0;
 
@@ -786,6 +787,7 @@ MQTT_InitLWT(MQTT_Client *mqttClient, uint8_t* will_topic, uint8_t* will_msg, ui
     mqttClient->connect_info.will_qos = will_qos;
     mqttClient->connect_info.will_retain = will_retain;
 }
+
 /**
   * @brief  Begin connect to MQTT broker
   * @param  client: MQTT_Client reference
@@ -819,16 +821,16 @@ MQTT_Connect(MQTT_Client *mqttClient)
     os_timer_setfn(&mqttClient->mqttTimer, (os_timer_func_t *)mqtt_timer, mqttClient);
     os_timer_arm(&mqttClient->mqttTimer, 1000, 1);
 
-    os_printf("your ESP SSL/TLS configuration is %d.[0:NO_TLS\t1:TLS_WITHOUT_AUTHENTICATION\t2ONE_WAY_ANTHENTICATION\t3TWO_WAY_ANTHENTICATION]\n",DEFAULT_SECURITY);
+    INFO("your ESP SSL/TLS configuration is %d.[0:NO_TLS\t1:TLS_WITHOUT_AUTHENTICATION\t2:ONE_WAY_ANTHENTICATION\t3:TWO_WAY_ANTHENTICATION]\n", MQTT_SECURITY);
     if (UTILS_StrToIP(mqttClient->host, &mqttClient->pCon->proto.tcp->remote_ip)) {
         INFO("TCP: Connect to ip  %s:%d\r\n", mqttClient->host, mqttClient->port);
         if (mqttClient->security)
         {
 #ifdef MQTT_SSL_ENABLE
-            if(DEFAULT_SECURITY >= ONE_WAY_ANTHENTICATION ) {
+            if(MQTT_SECURITY >= ONE_WAY_ANTHENTICATION ) {
                 espconn_secure_ca_enable(ESPCONN_CLIENT,CA_CERT_FLASH_ADDRESS);
             }
-            if(DEFAULT_SECURITY >= TWO_WAY_ANTHENTICATION) {
+            if(MQTT_SECURITY >= TWO_WAY_ANTHENTICATION) {
                 espconn_secure_cert_req_enable(ESPCONN_CLIENT,CLIENT_CERT_FLASH_ADDRESS);
             }
             espconn_secure_connect(mqttClient->pCon);

--- a/examples/esp_mqtt_proj/mqtt/mqtt_msg.c
+++ b/examples/esp_mqtt_proj/mqtt/mqtt_msg.c
@@ -296,7 +296,7 @@ mqtt_message_t* ICACHE_FLASH_ATTR mqtt_msg_connect(mqtt_connection_t* connection
 
   if(connection->message.length + sizeof(*variable_header) > connection->buffer_length)
     return fail_message(connection);
-  variable_header = (void*)(connection->buffer + connection->message.length);
+  variable_header = (struct mqtt_connect_variable_header*)(connection->buffer + connection->message.length);
   connection->message.length += sizeof(*variable_header);
 
   variable_header->lengthMsb = 0;

--- a/examples/esp_mqtt_proj/mqtt/utils.c
+++ b/examples/esp_mqtt_proj/mqtt/utils.c
@@ -38,7 +38,7 @@
 #include "utils.h"
 
 
-uint8_t ICACHE_FLASH_ATTR UTILS_IsIPV4 (int8_t *str)
+uint8_t ICACHE_FLASH_ATTR UTILS_IsIPV4 (const char *str)
 {
 	uint8_t segs = 0;   /* Segment count. */
 	uint8_t chcnt = 0;  /* Character count within segment. */
@@ -88,7 +88,7 @@ uint8_t ICACHE_FLASH_ATTR UTILS_IsIPV4 (int8_t *str)
 
     return 1;
 }
-uint8_t ICACHE_FLASH_ATTR UTILS_StrToIP(const int8_t* str, void *ip)
+uint8_t ICACHE_FLASH_ATTR UTILS_StrToIP(const char *str, void *ip)
 {
 
 	    /* The count of the number of bytes processed. */
@@ -127,7 +127,7 @@ uint8_t ICACHE_FLASH_ATTR UTILS_StrToIP(const int8_t* str, void *ip)
 	    return 1;
 
 }
-uint32_t ICACHE_FLASH_ATTR UTILS_Atoh(const int8_t *s)
+uint32_t ICACHE_FLASH_ATTR UTILS_Atoh(const char *s)
 {
 	uint32_t value = 0, digit;
 	int8_t c;


### PR DESCRIPTION
fix mqtt example compile warnings (e.g. char* instead of uint8_t* for strings)
rename DEFAULT_SECURITY to MQTT_SECURITY for better understanding