### PR TITLE
Fixed WiFi Manual Connection Crash LoadStoreErrorCause

### DIFF
--- a/ld/eagle.app.v6.ld
+++ b/ld/eagle.app.v6.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.new.1024.app1.ld
+++ b/ld/eagle.app.v6.new.1024.app1.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.new.1024.app2.ld
+++ b/ld/eagle.app.v6.new.1024.app2.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.new.2048.ld
+++ b/ld/eagle.app.v6.new.2048.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.new.512.app1.ld
+++ b/ld/eagle.app.v6.new.512.app1.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.new.512.app2.ld
+++ b/ld/eagle.app.v6.new.512.app2.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.old.1024.app1.ld
+++ b/ld/eagle.app.v6.old.1024.app1.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.old.1024.app2.ld
+++ b/ld/eagle.app.v6.old.1024.app2.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.old.512.app1.ld
+++ b/ld/eagle.app.v6.old.512.app1.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 

--- a/ld/eagle.app.v6.old.512.app2.ld
+++ b/ld/eagle.app.v6.old.512.app2.ld
@@ -85,6 +85,10 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
+
+	/* Fixed Wrong Data Section, Crash LoadStoreErrorCause by Sergei Sovik https://github.com/SergeiSovik */
+	*libnet80211.a:ieee80211_phy.o(.irom.text .irom.text.*)
+
     _data_end = ABSOLUTE(.);
   } >dram0_0_seg :dram0_0_phdr
 


### PR DESCRIPTION
libnet80211.a has wrong data placing in section .irom.text, which causes a critical error LoadStoreErrorCause, followed by a exception restart. This fix forces the linker to place data to the DRAM memory and completely eliminates the problem of starting WiFi in manual mode