### PR TITLE
Fixed gateway address issue. Closes #348

### DIFF
--- a/third_party/lwip/core/dhcp.c
+++ b/third_party/lwip/core/dhcp.c
@@ -1072,16 +1072,22 @@ dhcp_bind(struct netif *netif)
   if (dhcp->subnet_mask_given) {
     /* copy offered network mask */
     ip_addr_copy(sn_mask, dhcp->offered_sn_mask);
-  } else {
-    /* subnet mask not given, choose a safe subnet mask given the network class */
-    u8_t first_octet = ip4_addr1(&dhcp->offered_ip_addr);
-    if (first_octet <= 127) {
-      ip4_addr_set_u32(&sn_mask, PP_HTONL(0xff000000));
-    } else if (first_octet >= 192) {
-      ip4_addr_set_u32(&sn_mask, PP_HTONL(0xffffff00));
-    } else {
-      ip4_addr_set_u32(&sn_mask, PP_HTONL(0xffff0000));
-    }
+  } else { 
+     /* subnet mask not given */
+     if (!ip_addr_isany(&netif->ip_addr)) {
+	 /* if there is an IP lease use the previous mask */
+	 sn_mask = netif->netmask;
+     } else {
+	  /* choose a safe subnet mask given the network class */
+          u8_t first_octet = ip4_addr1(&dhcp->offered_ip_addr);
+          if (first_octet <= 127) {
+             ip4_addr_set_u32(&sn_mask, PP_HTONL(0xff000000));
+          } else if (first_octet >= 192) {
+             ip4_addr_set_u32(&sn_mask, PP_HTONL(0xffffff00));
+          } else {
+             ip4_addr_set_u32(&sn_mask, PP_HTONL(0xffff0000));
+          }
+     }
   }
 
   /* gateway address not given? */

--- a/third_party/lwip/core/dhcp.c
+++ b/third_party/lwip/core/dhcp.c
@@ -1084,15 +1084,14 @@ dhcp_bind(struct netif *netif)
     }
   }
 
-  ip_addr_copy(gw_addr, dhcp->offered_gw_addr);
   /* gateway address not given? */
-  if (ip_addr_isany(&gw_addr)) {
-    /* copy network address */
-    ip_addr_get_network(&gw_addr, &dhcp->offered_ip_addr, &sn_mask);
-    /* use first host address on network as gateway */
-    ip4_addr_set_u32(&gw_addr, ip4_addr_get_u32(&gw_addr) | PP_HTONL(0x00000001));
+  if (ip_addr_isany(&dhcp->offered_gw_addr) && !ip_addr_isany(&netif->gw)) {
+     /*Use the address previously received*/
+     ip_addr_copy(gw_addr, netif->gw);
+  } else {
+     ip_addr_copy(gw_addr, dhcp->offered_gw_addr);
   }
-
+	
 #if LWIP_DHCP_AUTOIP_COOP
   if(dhcp->autoip_coop_state == DHCP_AUTOIP_COOP_STATE_ON) {
     autoip_stop(netif);


### PR DESCRIPTION
This PR fixes the problem described in #348. It occurs when the DHCP server does not pass the gateway address during renewal. Below is an example of a frame with which the DHCP client has problems without this fix.

{0x02,0x01,0x06,0x00,0x32,0x99,0x72,0xcb,0x00,0x00,0x00,0x00,0x0a,0x00,0x04,0x96,0x0a,0x00,0x04,0x96,0x0a,0x00,0x04,0x01,0x00,0x00,0x00,0x00,0xf4,0xcf,0xa2,0xd1,0x07,0x72,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x63,0x82,0x53,0x63,0x35,0x01,0x05,0x36,0x04,0x0a,0x00,0x04,0x01,0x33,0x04,0x00,0x00,0x02,0x58,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}

